### PR TITLE
Release v1.0.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - name: "Okky Mabruri"
     website: "okkymabruri.github.io"
     orcid: "https://orcid.org/0000-0002-2103-1311"
-version: 1.0.0
+version: 1.0.1
 abstract: "news-watch: Indonesia's top news websites scraper. A Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 publisher: Zenodo
 doi: "10.5281/zenodo.14908389"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-12
+
+### Added
+- Append-only JSONL health history persistence (`--health-history` flag, `NEWSWATCH_HEALTH_HISTORY` env, flag-overrides-env precedence) wired into `--health-report`
+- Registry-driven source documentation: doc generator emits source blocks from the registry; Makefile `sources` targets and six marked doc regions now reflect registry output
+- Required/offline test split: lint, sources-check, and unit tests run deterministically; live scraper checks moved to an advisory, sharded, cached matrix
+
+### Fixed
+- JPNN: parse English month dates as DMY in article metadata
+- BeritaSatu: match the current article body selector
+- Republika: trust tag-page search relevance so tag results surface in strict search
+- Offline test isolation: skip `browser_required` slugs in the required offline suite (search and latest)
+- Docs: restore registry-driven source documentation after prior drift
+
+### Changed
+- Live scraper probes: cache results and skip on upstream flakes to reduce CI noise
+
 ## [1.0.0] - 2026-06-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "news-watch"
-version = "1.0.0"
+version = "1.0.1"
 description = "news-watch is a Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/newswatch/__init__.py
+++ b/src/newswatch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # health report
 from .health import health_report as health_report

--- a/uv.lock
+++ b/uv.lock
@@ -792,7 +792,7 @@ wheels = [
 
 [[package]]
 name = "news-watch"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Prepare news-watch v1.0.1 after the registry, health-history, scraper-validation, documentation, and CI improvements merged to main.

## Version metadata

- Set package version to 1.0.1 in pyproject.toml and newswatch.__version__.
- Update CITATION.cff and uv.lock.
- Add the 1.0.1 changelog section dated 2026-07-12.

## Validation

- make release-validate VERSION=1.0.1
- uv lock --check
- uv run --extra dev ruff check
- uv run --extra dev pytest tests/ -m "not network" -q — 678 passed, 19 skipped, 186 deselected
- uv run --extra dev make sources-check