### PR TITLE
Harden release preparation and publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -129,7 +129,7 @@ jobs:
           uv run python scripts/release_notes.py "$VERSION" > release-notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           body_path: release-notes.md
           draft: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-${{ matrix.python-version }}
           path: .omp/test-results/junit.xml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint format release-notes release-notes-file release-notes-publish release release-patch release-minor release-major release-validate sources sources-check
+.PHONY: test lint format release-notes release-notes-file release-notes-publish release release-prepare release-publish release-patch release-minor release-major release-validate sources sources-check
 
 test:
 	@uv run --extra dev pytest
@@ -36,18 +36,25 @@ release-notes-publish: release-validate
 	@uv run python scripts/release_notes.py $(VERSION) > /tmp/news-watch-v$(VERSION)-notes.md
 	@gh release edit v$(VERSION) --notes-file /tmp/news-watch-v$(VERSION)-notes.md
 
+release: release-publish
+
+
+release-prepare:
+	@test -n "$(VERSION)" || (echo "Error: Set VERSION=x.y.z" && exit 1)
+	@uv run python scripts/version.py prepare "$(VERSION)"
+
 release-patch:
-	@uv run python scripts/version.py release
+	@uv run python scripts/version.py prepare --patch
 
 release-minor:
-	@uv run python scripts/version.py release --minor
+	@uv run python scripts/version.py prepare --minor
 
 release-major:
-	@uv run python scripts/version.py release --major
+	@uv run python scripts/version.py prepare --major
 
-release:
-	@test -n "$(VERSION)" || (echo "Error: Set VERSION=x.y.z" && exit 1)
-	@uv run python scripts/version.py release $(VERSION)
+
+release-publish: release-validate
+	@uv run python scripts/version.py publish "$(VERSION)"
 
 sources:
 	@uv run python scripts/generate_sources.py

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
-"""Simple version management for news-watch."""
+"""Prepare and publish news-watch releases."""
 
+import os
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def validate_version(version):
+    """Require an exact semantic x.y.z version."""
+    if not VERSION_PATTERN.fullmatch(version):
+        sys.exit(f"Error: invalid version {version!r}; expected x.y.z")
+    return version
 
 
 def get_current_version():
@@ -16,137 +26,184 @@ def get_current_version():
     return match.group(1)
 
 
-def bump_version(version, part):
-    """Bump version number."""
-    major, minor, patch = map(int, version.split("."))
 
+
+def bump_version(version, part):
+    """Return the requested semantic-version bump."""
+    validate_version(version)
+    major, minor, patch = map(int, version.split("."))
     if part == "major":
         return f"{major + 1}.0.0"
     if part == "minor":
         return f"{major}.{minor + 1}.0"
-    return f"{major}.{minor}.{patch + 1}"  # patch
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _replace_marker(path, pattern, replacement):
+    content = path.read_text()
+    updated, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+    if count != 1:
+        sys.exit(f"Error: expected one version marker in {path}, found {count}")
+    return updated
 
 
 def update_version_files(new_version):
-    """Update version in pyproject.toml, src/newswatch/__init__.py, and CITATION.cff."""
-    pyproject_path = Path("pyproject.toml")
-    content = pyproject_path.read_text()
-    new_content = re.sub(
-        r'^version\s*=\s*"[^"]+"',
-        f'version = "{new_version}"',
-        content,
-        flags=re.MULTILINE,
-    )
-    pyproject_path.write_text(new_content)
-    print(f"Updated pyproject.toml to v{new_version}")
-
-    init_path = Path("src/newswatch/__init__.py")
-    init_content = init_path.read_text()
-    new_init_content = re.sub(
-        r'__version__\s*=\s*"[^"]+"',
-        f'__version__ = "{new_version}"',
-        init_content,
-    )
-    init_path.write_text(new_init_content)
-    print(f"Updated src/newswatch/__init__.py to v{new_version}")
-
-    citation_path = Path("CITATION.cff")
-    if citation_path.exists():
-        citation_content = citation_path.read_text()
-        new_citation_content = re.sub(
+    """Update every source version marker."""
+    validate_version(new_version)
+    updates = {
+        Path("pyproject.toml"): _replace_marker(
+            Path("pyproject.toml"),
+            r'^version\s*=\s*"[^"]+"',
+            f'version = "{new_version}"',
+        ),
+        Path("src/newswatch/__init__.py"): _replace_marker(
+            Path("src/newswatch/__init__.py"),
+            r'^__version__\s*=\s*"[^"]+"',
+            f'__version__ = "{new_version}"',
+        ),
+        Path("CITATION.cff"): _replace_marker(
+            Path("CITATION.cff"),
             r"^version:\s*.+$",
             f"version: {new_version}",
-            citation_content,
-            flags=re.MULTILINE,
-        )
-        citation_path.write_text(new_citation_content)
-        print(f"Updated CITATION.cff to v{new_version}")
+        ),
+    }
+
+    for path, content in updates.items():
+        path.write_text(content)
+        print(f"Updated {path} to v{new_version}")
 
 
-def files_already_at_version(version):
-    """Check if version markers already match target version."""
-    # Check pyproject.toml
-    pyproject = Path("pyproject.toml").read_text()
-    pyproject_match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
-    if not pyproject_match or pyproject_match.group(1) != version:
-        return False
-
-    # Check __init__.py
-    init_content = Path("src/newswatch/__init__.py").read_text()
-    init_match = re.search(r'__version__\s*=\s*"([^"]+)"', init_content)
-    if not init_match or init_match.group(1) != version:
-        return False
-
-    # Check CITATION.cff if exists
-    citation_path = Path("CITATION.cff")
-    if citation_path.exists():
-        citation_content = citation_path.read_text()
-        citation_match = re.search(r"^version:\s*(.+)$", citation_content, re.MULTILINE)
-        if not citation_match or citation_match.group(1).strip() != version:
-            return False
-
-    return True
+def _read_marker(path, pattern, description):
+    content = path.read_text()
+    match = re.search(pattern, content, re.MULTILINE)
+    if not match:
+        sys.exit(f"Error: {description} version not found in {path}")
+    return match.group(1).strip()
 
 
-def git_commit_and_tag(version):
-    """Commit version change, create tag, and push."""
+def _read_lock_version():
+    content = Path("uv.lock").read_text()
+    packages = re.finditer(
+        r'^\[\[package\]\]\s*$\n(?P<body>.*?)(?=^\[\[package\]\]\s*$|\Z)',
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    for package in packages:
+        body = package.group("body")
+        if re.search(r'^name\s*=\s*"news-watch"\s*$', body, re.MULTILINE):
+            match = re.search(r'^version\s*=\s*"([^"]+)"\s*$', body, re.MULTILINE)
+            if not match:
+                sys.exit("Error: news-watch version not found in uv.lock")
+            return match.group(1)
+    sys.exit("Error: news-watch package not found in uv.lock")
+
+
+def verify_version_markers(version):
+    """Require all release metadata to match the target version."""
+    markers = {
+        "pyproject.toml": get_current_version(),
+        "src/newswatch/__init__.py": _read_marker(
+            Path("src/newswatch/__init__.py"),
+            r'^__version__\s*=\s*"([^"]+)"',
+            "package",
+        ),
+        "CITATION.cff": _read_marker(
+            Path("CITATION.cff"), r"^version:\s*(.+)$", "citation"
+        ),
+        "uv.lock": _read_lock_version(),
+    }
+    for path, actual in markers.items():
+        if actual != version:
+            sys.exit(
+                f"Error: VERSION={version} does not match {path} version={actual}"
+            )
+
+
+def verify_changelog(version):
+    """Require release notes for the target version."""
+    changelog = Path("docs/changelog.md").read_text()
+    if not re.search(rf"^## \[{re.escape(version)}\](?:\s|$)", changelog, re.MULTILINE):
+        sys.exit(f"Error: no ## [{version}] section found in docs/changelog.md")
+
+
+def _run_git(*args, capture_output=False):
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GCM_INTERACTIVE"] = "never"
+    env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+    return subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=capture_output,
+        text=True,
+        env=env,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _git_output(*args):
+    return _run_git(*args, capture_output=True).stdout.strip()
+
+
+def verify_publish_state(version):
+    """Require a clean prepared commit at origin/main."""
+    branch = _git_output("branch", "--show-current")
+    if branch != "main":
+        sys.exit(f"Error: release publication requires main, current branch is {branch}")
+
+    if _git_output("status", "--porcelain"):
+        sys.exit("Error: release publication requires a clean worktree")
+
+    _run_git("fetch", "origin", "main")
+
+    head = _git_output("rev-parse", "HEAD")
+    upstream = _git_output("rev-parse", "origin/main")
+    if head != upstream:
+        sys.exit("Error: HEAD does not match origin/main")
+
     tag = f"v{version}"
+    if _git_output("tag", "--list", tag):
+        sys.exit(f"Error: tag {tag} already exists")
 
-    result = subprocess.run(["git", "tag", "-l", tag], capture_output=True, text=True)
-    if result.stdout.strip():
-        print(f"Tag {tag} already exists")
-        return
+    if _git_output("ls-remote", "--tags", "origin", f"refs/tags/{tag}"):
+        sys.exit(f"Error: tag {tag} already exists on origin")
 
-    # If files already at target version (e.g. after PR merge), skip commit
-    if files_already_at_version(version):
-        print("Version files already updated. Creating tag on current HEAD.")
-    else:
-        to_add = ["pyproject.toml", "src/newswatch/__init__.py", "uv.lock"]
-        if Path("CITATION.cff").exists():
-            to_add.append("CITATION.cff")
-        subprocess.run(["git", "add", *to_add], check=True)
-        subprocess.run(["git", "commit", "-m", f"Bump version to {version}"], check=True)
-        print("Committed version changes")
 
-    subprocess.run(["git", "tag", "-a", tag, "-m", f"Release {tag}"], check=True)
-    print(f"Created tag {tag}")
+def prepare_release(version):
+    """Update release metadata and refresh the lockfile."""
+    validate_version(version)
+    update_version_files(version)
+    subprocess.run(["uv", "lock"], check=True)
+    print(f"Prepared version {version}. Review and commit the changes before publishing.")
 
-    response = input(f"Push tag {tag} to remote? (y/n): ")
-    if response.lower() == "y":
-        subprocess.run(["git", "push"], check=True)
-        subprocess.run(["git", "push", "origin", tag], check=True)
-        print(f"Pushed tag {tag}")
-        print("GitHub Actions will now publish to PyPI automatically.")
+
+def publish_release(version):
+    """Validate and publish an annotated release tag."""
+    validate_version(version)
+    verify_version_markers(version)
+    verify_changelog(version)
+    verify_publish_state(version)
+
+    tag = f"v{version}"
+    _run_git("tag", "-a", tag, "-m", f"Release {tag}")
+    _run_git("push", "origin", tag)
+    print(f"Published tag {tag}")
 
 
 def main():
-    if len(sys.argv) < 2:
-        sys.exit("Usage: python scripts/version.py release [--major|--minor|VERSION]")
+    if len(sys.argv) != 3 or sys.argv[1] not in {"prepare", "publish"}:
+        sys.exit(
+            "Usage: python scripts/version.py prepare {VERSION|--patch|--minor|--major}\n"
+            "       python scripts/version.py publish VERSION"
+        )
 
-    if sys.argv[1] != "release":
-        sys.exit("Only 'release' command supported")
-
-    current = get_current_version()
-    print(f"Current version: {current}")
-
-    if len(sys.argv) == 2:
-        new_version = bump_version(current, "patch")
-    elif sys.argv[2] == "--major":
-        new_version = bump_version(current, "major")
-    elif sys.argv[2] == "--minor":
-        new_version = bump_version(current, "minor")
+    command, value = sys.argv[1:]
+    if command == "prepare":
+        if value in {"--patch", "--minor", "--major"}:
+            value = bump_version(get_current_version(), value[2:])
+        prepare_release(value)
     else:
-        new_version = sys.argv[2]
-
-    print(f"Target version: {new_version}")
-    response = input("Continue? (y/n): ")
-    if response.lower() != "y":
-        print("Cancelled")
-        return
-
-    update_version_files(new_version)
-    git_commit_and_tag(new_version)
-    print(f"\nDone! Version {new_version} released.")
+        publish_release(value)
 
 
 if __name__ == "__main__":

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,232 @@
+"""Tests for explicit release preparation and publication."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "version.py"
+SPEC = importlib.util.spec_from_file_location("version_script", SCRIPT)
+assert SPEC and SPEC.loader
+version_script = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(version_script)
+
+
+def _write_release_files(root: Path, version: str = "1.2.3") -> None:
+    (root / "src/newswatch").mkdir(parents=True)
+    (root / "docs").mkdir()
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "news-watch"\nversion = "{version}"\n'
+    )
+    (root / "src/newswatch/__init__.py").write_text(
+        f'__version__ = "{version}"\n'
+    )
+    (root / "CITATION.cff").write_text(f"cff-version: 1.2.0\nversion: {version}\n")
+    (root / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "dependency"\nversion = "9.0.0"\n'
+        f'\n[[package]]\nname = "news-watch"\nversion = "{version}"\n'
+    )
+    (root / "docs/changelog.md").write_text(
+        f"# Changelog\n\n## [{version}] - 2026-07-12\n\n- Release.\n"
+    )
+
+
+def _git_runner(outputs, calls):
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        key = tuple(command[1:])
+        return subprocess.CompletedProcess(command, 0, stdout=outputs.get(key, ""))
+
+    return run
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1.2", "1.2.3.4", "v1.2.3", "1.2.x", "1.2.3-rc1", " 1.2.3"],
+)
+def test_validate_version_rejects_non_x_y_z(value):
+    with pytest.raises(SystemExit, match="expected x.y.z"):
+        version_script.validate_version(value)
+
+
+def test_prepare_updates_metadata_and_only_runs_uv_lock(tmp_path, monkeypatch):
+    _write_release_files(tmp_path, "1.2.3")
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(version_script.subprocess, "run", run)
+
+    version_script.prepare_release("2.0.0")
+
+    assert 'version = "2.0.0"' in (tmp_path / "pyproject.toml").read_text()
+    assert '__version__ = "2.0.0"' in (
+        tmp_path / "src/newswatch/__init__.py"
+    ).read_text()
+    assert "version: 2.0.0" in (tmp_path / "CITATION.cff").read_text()
+    assert calls == [(["uv", "lock"], {"check": True})]
+
+
+def test_prepare_rejects_invalid_version_before_files_or_commands(tmp_path, monkeypatch):
+    _write_release_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    before = {
+        path: (tmp_path / path).read_text()
+        for path in ("pyproject.toml", "src/newswatch/__init__.py", "CITATION.cff")
+    }
+    calls = []
+    monkeypatch.setattr(
+        version_script.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(SystemExit, match="expected x.y.z"):
+        version_script.prepare_release("v2.0.0")
+
+    assert calls == []
+    assert all((tmp_path / path).read_text() == content for path, content in before.items())
+
+
+def test_publish_validates_then_creates_and_pushes_only_tag(tmp_path, monkeypatch):
+    _write_release_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = []
+    outputs = {
+        ("branch", "--show-current"): "main\n",
+        ("status", "--porcelain"): "",
+        ("rev-parse", "HEAD"): "abc123\n",
+        ("rev-parse", "origin/main"): "abc123\n",
+        ("tag", "--list", "v1.2.3"): "",
+        ("ls-remote", "--tags", "origin", "refs/tags/v1.2.3"): "",
+    }
+    monkeypatch.setattr(version_script.subprocess, "run", _git_runner(outputs, calls))
+
+    version_script.publish_release("1.2.3")
+
+    commands = [call[0] for call in calls]
+    assert ["git", "fetch", "origin", "main"] in commands
+    assert commands[-2:] == [
+        ["git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"],
+        ["git", "push", "origin", "v1.2.3"],
+    ]
+    assert all(command[0] == "git" for command in commands)
+    for _, kwargs in calls:
+        assert kwargs["check"] is True
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+        assert kwargs["env"]["GCM_INTERACTIVE"] == "never"
+        assert kwargs["env"]["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+
+@pytest.mark.parametrize(
+    ("outputs", "message"),
+    [
+        ({("branch", "--show-current"): "feature\n"}, "requires main"),
+        (
+            {
+                ("branch", "--show-current"): "main\n",
+                ("status", "--porcelain"): " M pyproject.toml\n",
+            },
+            "clean worktree",
+        ),
+        (
+            {
+                ("branch", "--show-current"): "main\n",
+                ("status", "--porcelain"): "",
+                ("rev-parse", "HEAD"): "local\n",
+                ("rev-parse", "origin/main"): "remote\n",
+            },
+            "HEAD does not match origin/main",
+        ),
+        (
+            {
+                ("branch", "--show-current"): "main\n",
+                ("status", "--porcelain"): "",
+                ("rev-parse", "HEAD"): "same\n",
+                ("rev-parse", "origin/main"): "same\n",
+                ("tag", "--list", "v1.2.3"): "v1.2.3\n",
+            },
+            "already exists",
+        ),
+        (
+            {
+                ("branch", "--show-current"): "main\n",
+                ("status", "--porcelain"): "",
+                ("rev-parse", "HEAD"): "same\n",
+                ("rev-parse", "origin/main"): "same\n",
+                ("tag", "--list", "v1.2.3"): "",
+                ("ls-remote", "--tags", "origin", "refs/tags/v1.2.3"): "remote-tag\n",
+            },
+            "already exists on origin",
+        ),
+    ],
+)
+def test_publish_rejects_unsafe_git_state_without_mutation(
+    tmp_path, monkeypatch, outputs, message
+):
+    _write_release_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = []
+    monkeypatch.setattr(version_script.subprocess, "run", _git_runner(outputs, calls))
+
+    with pytest.raises(SystemExit, match=message):
+        version_script.publish_release("1.2.3")
+
+    assert not any(call[0][1:3] in (["tag", "-a"], ["push", "origin"]) for call in calls)
+
+
+@pytest.mark.parametrize(
+    ("path", "old", "new", "message"),
+    [
+        ("pyproject.toml", 'version = "1.2.3"', 'version = "1.2.4"', "pyproject"),
+        (
+            "src/newswatch/__init__.py",
+            '__version__ = "1.2.3"',
+            '__version__ = "1.2.4"',
+            "__init__",
+        ),
+        ("CITATION.cff", "version: 1.2.3", "version: 1.2.4", "CITATION"),
+        ("uv.lock", 'version = "1.2.3"', 'version = "1.2.4"', "uv.lock"),
+        ("docs/changelog.md", "## [1.2.3]", "## [1.2.4]", "changelog"),
+    ],
+)
+def test_publish_rejects_unprepared_metadata_before_git(
+    tmp_path, monkeypatch, path, old, new, message
+):
+    _write_release_files(tmp_path)
+    target = tmp_path / path
+    target.write_text(target.read_text().replace(old, new))
+    monkeypatch.chdir(tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        version_script.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(SystemExit, match=message):
+        version_script.publish_release("1.2.3")
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("part", "expected"),
+    [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0")],
+)
+def test_bump_version(part, expected):
+    assert version_script.bump_version("1.2.3", part) == expected
+
+
+def test_main_exposes_only_prepare_and_publish(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["version.py", "release", "1.2.3"])
+
+    with pytest.raises(SystemExit, match=r"(?s)prepare .*publish"):
+        version_script.main()


### PR DESCRIPTION
## Summary

- Upgrade artifact and GitHub Release actions to current Node.js 24-compatible releases, pinned by commit SHA.
- Separate version preparation from tag publication.
- Make release publication non-interactive and guard it with clean-main, refreshed origin parity, metadata, changelog, and tag checks.
- Add deterministic release workflow tests.

## Release interface

```bash
make release-prepare VERSION=x.y.z
make release-patch
make release-minor
make release-major
make release VERSION=x.y.z
```

Preparation updates version metadata and `uv.lock` only. After the prepared PR merges, publication runs from clean, synchronized `main` and pushes only the annotated version tag.

## Validation

- `uv run --extra dev pytest tests/test_version.py -q` — 23 passed
- `uv run --extra dev pytest tests/ -m "not network" -q` — 701 passed, 19 skipped, 186 deselected
- `uv run --extra dev ruff check` — passed
- Workflow YAML parsing — passed
- `uv run --extra dev make sources-check` — passed

Local `AGENTS.md` release guidance was updated but remains intentionally ignored and is not part of this PR.
