### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - name: "Okky Mabruri"
     website: "okkymabruri.github.io"
     orcid: "https://orcid.org/0000-0002-2103-1311"
-version: 1.0.1
+version: 1.1.0
 abstract: "news-watch: Indonesia's top news websites scraper. A Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 publisher: Zenodo
 doi: "10.5281/zenodo.14908389"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2026-07-13
 ### Added
 - Alinea.id, Betahita, Good News From Indonesia, NusaBali, and The Conversation Indonesia with search and latest support
 - Hukumonline and Independen.id with latest support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "news-watch"
-version = "1.0.1"
+version = "1.1.0"
 description = "news-watch is a Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/newswatch/__init__.py
+++ b/src/newswatch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 # health report
 from .health import health_report as health_report

--- a/uv.lock
+++ b/uv.lock
@@ -792,7 +792,7 @@ wheels = [
 
 [[package]]
 name = "news-watch"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release preparation for v1.1.0.

## Metadata
- Version bump: 1.0.1 -> 1.1.0
- Files: CITATION.cff, docs/changelog.md, pyproject.toml, src/newswatch/__init__.py, uv.lock
- Commit: chore(release): prepare v1.1.0

## Changelog
- Added 1.1.0 entry (2026-07-13) to docs/changelog.md alongside the version bump across CITATION.cff, pyproject.toml, src/newswatch/__init__.py, and uv.lock.

## Verification
- release-validate: PASSED (Main)
- 272 focused tests: PASSED (Main)
- Ruff: PASSED (Main)
- sources-check: PASSED (Main)
- diff-check: PASSED (Main)