### PR TITLE
1.2.3 release: NTVNews, bounded search/latest pagination, publisher-contract repairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The output file contains the following columns:
 - `latest` is intended for latest-news monitoring and does not require keywords.
 
 <!-- BEGIN GENERATED: readme-heading -->
-## Supported Websites (78)
+## Supported Websites (79)
 <!-- END GENERATED: readme-heading -->
 <!-- BEGIN GENERATED: readme-sources -->
 [Alinea.id](https://www.alinea.id),
@@ -217,6 +217,7 @@ The output file contains the following columns:
 [Mojok](https://mojok.co),
 [Mongabay Indonesia](https://mongabay.co.id),
 [Niaga.Asia](https://www.niaga.asia),
+[NTVNews.id](https://www.ntvnews.id),
 [NusaBali](https://www.nusabali.com),
 [Okezone](https://okezone.com),
 [Pantau.com](https://www.pantau.com),
@@ -245,8 +246,8 @@ The output file contains the following columns:
 
 <!-- BEGIN GENERATED: readme-counts -->
 > **Notes:**
-> - 78 registered sources: 73 with keyword search, 78 with latest mode.
-> - 76 stable scrapers in the current release: 71 with keyword search, 76 with latest mode.
+> - 79 registered sources: 74 with keyword search, 79 with latest mode.
+> - 77 stable scrapers in the current release: 72 with keyword search, 77 with latest mode.
 > - 1 source under investigation; 1 source quarantined.
 > - AP News uses topic hub pages with keyword-in-title filtering (robots disallows /search?q=*).
 > - Al Jazeera is latest-only via RSS feed (search page is JS-rendered).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -190,13 +190,13 @@ except NewsWatchError as exc:
 <!-- BEGIN GENERATED: api-notes -->
 ## Stable API Notes
 
-All 78 registered scrapers are exposed via `list_scrapers()` and the public `SCRAPERS` mapping. 73 of them support the `search` method; all 78 support `latest`.
+All 79 registered scrapers are exposed via `list_scrapers()` and the public `SCRAPERS` mapping. 74 of them support the `search` method; all 79 support `latest`.
 
 ## Notes
 
 - Prefer `scrapers="auto"` unless you know which sites you need.
 - Cloud/server environments are more likely to be blocked.
-- Stable support currently covers 76 scrapers (71 search-capable, 76 latest-capable).
+- Stable support currently covers 77 scrapers (72 search-capable, 77 latest-capable).
 - 1 source under investigation; 1 source quarantined.
 
 **Empty results**: Check if your keywords are in Indonesian or try broader terms.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,8 +62,8 @@ Latest support is validated independently; a source can be latest-only.
 
 | State | Count |
 |---|---|
-| registered | 78 |
-| stable | 76 |
+| registered | 79 |
+| stable | 77 |
 | quarantined | 1 |
 | investigating | 1 |
 <!-- END GENERATED: architecture-state -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- NTVNews.id (`ntvnews`) with bounded Google News sitemap search and latest discovery
+
 ## [1.2.2] - 2026-07-19
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Applied `--max-pages` to both search and latest retrieval, with independent per-mode scraper bounds.
+
+### Fixed
+- Scoped Alinea search discovery to primary result cards and bounded repeated search pagination.
+- Updated Grid, Kaltim Post, Hukumonline, NusaBali, Kumparan, DailySocial, Katadata, and VOI extraction or discovery contracts to match current publisher pages.
 
 ## [1.2.2] - 2026-07-19
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 <!-- BEGIN GENERATED: index-summary -->
 news-watch scrapes structured news data from Indonesia's top news websites with keyword/date search and latest-news monitoring.
 
-The current stable release supports 76 news scrapers (71 Indonesian/global sources with search mode, 76 with latest mode). 78 sources are registered in total: 1 source under investigation; 1 source quarantined.
+The current stable release supports 77 news scrapers (72 Indonesian/global sources with search mode, 77 with latest mode). 79 sources are registered in total: 1 source under investigation; 1 source quarantined.
 <!-- END GENERATED: index-summary -->
 
 ## Install

--- a/docs/practical-guide.md
+++ b/docs/practical-guide.md
@@ -56,10 +56,10 @@ nw.list_scrapers(method="latest") # sources that support latest mode
 For larger sweeps, narrow the date window or `--limit` to bound cost; for noisy periods, narrow `--scrapers` before retrying.
 
 <!-- BEGIN GENERATED: guide-counts -->
-The stable release currently exposes 76 supported scrapers. 1 source under investigation; 1 source quarantined.
+The stable release currently exposes 77 supported scrapers. 1 source under investigation; 1 source quarantined.
 
-71 of 76 stable sources support keyword search; 76 support latest monitoring.
-The full registry contains 78 sources: 73 support keyword search and 78 support latest monitoring.
+72 of 77 stable sources support keyword search; 77 support latest monitoring.
+The full registry contains 79 sources: 74 support keyword search and 79 support latest monitoring.
 <!-- END GENERATED: guide-counts -->
 
 ## Saving results

--- a/scripts/generate_sources.py
+++ b/scripts/generate_sources.py
@@ -81,6 +81,7 @@ SOURCE_URLS: Dict[str, str] = {
     "mojok": "https://mojok.co",
     "mongabay": "https://mongabay.co.id",
     "nusabali": "https://www.nusabali.com",
+    "ntvnews": "https://www.ntvnews.id",
     "okezone": "https://okezone.com",
     "pantau": "https://www.pantau.com",
     "pikiranrakyat": "https://pikiran-rakyat.com",

--- a/src/newswatch/api.py
+++ b/src/newswatch/api.py
@@ -252,9 +252,11 @@ async def _async_scrape_to_list(
                 queue_=queue,
                 **scraper_params,
             )
-            # Apply max_pages limit for latest mode
             if max_pages is not None:
-                scraper_instance.max_latest_pages = max_pages
+                if method == "search":
+                    scraper_instance.max_pages = max_pages
+                else:
+                    scraper_instance.max_latest_pages = max_pages
             # Wire dedup and time window to scraper for pre-fetch filtering
             if dedup_links is not None:
                 scraper_instance.dedup_links = dedup_links
@@ -422,7 +424,7 @@ def scrape(
         timeout (int): Maximum time in seconds for scraping operation
         method (str): Retrieval method - "search" or "latest"
         limit (int | None): Maximum number of articles to collect (latest mode)
-        max_pages (int | None): Maximum pages to fetch per scraper (latest mode)
+        max_pages (int | None): Maximum pages to fetch per scraper
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.
         proxy (str | None): Proxy URL for all requests (e.g. 'http://user:pass@proxy.example.com:8080', 'socks5://proxy.example.com:1080'). Sets NEWSWATCH_PROXY.
@@ -500,7 +502,7 @@ def scrape_to_dataframe(
         timeout (int): Maximum time in seconds for scraping operation
         method (str): Retrieval method - "search" or "latest"
         limit (int | None): Maximum number of articles to collect (latest mode)
-        max_pages (int | None): Maximum pages to fetch per scraper (latest mode)
+        max_pages (int | None): Maximum pages to fetch per scraper
         scraper_timeout (int | None): Per-scraper timeout in seconds
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.
@@ -581,7 +583,7 @@ def scrape_to_file(
         timeout (int): Maximum time in seconds for scraping operation
         method (str): Retrieval method - "search" or "latest"
         limit (int | None): Maximum number of articles to collect (latest mode)
-        max_pages (int | None): Maximum pages to fetch per scraper (latest mode)
+        max_pages (int | None): Maximum pages to fetch per scraper
         scraper_timeout (int | None): Per-scraper timeout in seconds
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.

--- a/src/newswatch/cli.py
+++ b/src/newswatch/cli.py
@@ -84,7 +84,7 @@ def cli():
         "--max-pages",
         type=int,
         default=None,
-        help="Maximum number of pages to fetch per scraper in latest mode.",
+        help="Maximum number of pages to fetch per scraper.",
     )
     parser.add_argument(
         "--scraper-timeout",

--- a/src/newswatch/main.py
+++ b/src/newswatch/main.py
@@ -507,9 +507,11 @@ async def main(args):
             scraper_instance = scraper_class(
                 keywords, start_date=start_date, queue_=queue_, **scraper_params
             )
-            # Apply max_pages limit for latest mode
             if max_pages is not None:
-                scraper_instance.max_latest_pages = max_pages
+                if method == "search":
+                    scraper_instance.max_pages = max_pages
+                else:
+                    scraper_instance.max_latest_pages = max_pages
             scrapers.append(scraper_instance)
         else:
             logging.warning(f"scraper '{scraper_name}' is not recognized.")

--- a/src/newswatch/registry.py
+++ b/src/newswatch/registry.py
@@ -453,6 +453,18 @@ _SCRAPER_ENTRIES: Tuple[ScraperEntry, ...] = (
         supports_latest=True,
     ),
     ScraperEntry(
+        "ntvnews",
+        "NTVNews.id",
+        "ntvnews", "NTVNewsScraper",
+        status="stable",
+        strict_search=True,
+        concurrency=5,
+        smoke_keyword="indonesia",
+        supports_search=True,
+        supports_latest=True,
+        note="single Google News sitemap search (title-only); latest unfiltered; Dewan Pers verified 2024-11-25",
+    ),
+    ScraperEntry(
         "sindonews",
         "SINDOnews",
         "sindonews", "SindonewsScraper",

--- a/src/newswatch/scrapers/__init__.py
+++ b/src/newswatch/scrapers/__init__.py
@@ -42,6 +42,7 @@ from .metrotvnews import MetrotvnewsScraper as MetrotvnewsScraper
 from .niagaasia import NiagaAsiaScraper as NiagaAsiaScraper
 from .mojok import MojokScraper as MojokScraper
 from .mongabay import MongabayScraper as MongabayScraper
+from .ntvnews import NTVNewsScraper as NTVNewsScraper
 from .okezone import OkezoneScraper as OkezoneScraper
 from .pantau import PantauScraper as PantauScraper
 from .pikiranrakyat import PikiranRakyatScraper as PikiranRakyatScraper
@@ -111,6 +112,7 @@ __all__ = [
     "NiagaAsiaScraper",
     "MojokScraper",
     "MongabayScraper",
+    "NTVNewsScraper",
     "OkezoneScraper",
     "PantauScraper",
     "PikiranRakyatScraper",

--- a/src/newswatch/scrapers/alinea.py
+++ b/src/newswatch/scrapers/alinea.py
@@ -47,14 +47,17 @@ class AlineaScraper(BaseScraper):
             return None
         soup = BeautifulSoup(response_text, "html.parser")
         links = set()
-        for a in soup.find_all("a", href=True):
-            href = a["href"]
-            if href.startswith("/"):
-                href = f"{self.BASE_URL}{href}"
-            if not href.startswith("http"):
+        for card in soup.select(".hasilcari .box1"):
+            if card.find_parent(class_="section-popular"):
                 continue
-            if self.ARTICLE_RE.match(href):
-                links.add(href)
+            for a in card.select("a[href]"):
+                href = a["href"]
+                if href.startswith("/"):
+                    href = f"{self.BASE_URL}{href}"
+                if not href.startswith("http"):
+                    continue
+                if self.ARTICLE_RE.match(href):
+                    links.add(href)
         if not links:
             self.continue_scraping = False
         return links or None

--- a/src/newswatch/scrapers/basescraper.py
+++ b/src/newswatch/scrapers/basescraper.py
@@ -16,6 +16,7 @@ class BaseScraper(AsyncScraper, ABC):
         dedup_links=None,
         start_datetime=None,
         end_datetime=None,
+        max_pages=None,
     ):
         super().__init__(concurrency)
         self.keywords = (
@@ -26,6 +27,7 @@ class BaseScraper(AsyncScraper, ABC):
         self.queue_ = queue_
         self.continue_scraping = True
         self.max_latest_pages = max_latest_pages if max_latest_pages is not None else 1
+        self.max_pages = max_pages
         self.dedup_links = dedup_links or set()
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
@@ -59,7 +61,10 @@ class BaseScraper(AsyncScraper, ABC):
         page = 1
         found_articles = False
 
-        while self.continue_scraping:
+        while (
+            self.continue_scraping
+            and (self.max_pages is None or page <= self.max_pages)
+        ):
             response_text = await self.build_search_url(keyword, page)
             if not response_text:
                 break

--- a/src/newswatch/scrapers/dailysocial.py
+++ b/src/newswatch/scrapers/dailysocial.py
@@ -39,14 +39,12 @@ class DailySocialScraper(BaseScraper):
             return None
         soup = BeautifulSoup(response_text, "html.parser")
 
-        # Find article containers
-        items = soup.select(".wp-block-post")
-        if not items:
+        anchors = soup.select("article.type-post .entry-title a[href]")
+        if not anchors:
             return None
 
         links = set()
-        for item in items:
-            a = item.select_one("a[href]")
+        for a in anchors:
             if a:
                 href = a["href"]
                 full_url = urljoin(self.base_url, href) if not href.startswith("http") else href
@@ -193,9 +191,8 @@ class DailySocialScraper(BaseScraper):
             return None
         soup = BeautifulSoup(response_text, "html.parser")
         links = set()
-        items = soup.select(".wp-block-post")
-        for item in items:
-            a = item.select_one("a[href]")
+        anchors = soup.select("article.type-post .entry-title a[href]")
+        for a in anchors:
             if a:
                 href = a["href"]
                 full_url = urljoin(self.base_url, href) if not href.startswith("http") else href

--- a/src/newswatch/scrapers/grid.py
+++ b/src/newswatch/scrapers/grid.py
@@ -62,12 +62,10 @@ class GridScraper(BaseScraper):
         if not title:
             return
 
-        # Content
-        content_div = soup.select_one(".detail-read__content")
-        if not content_div:
-            content_div = soup.select_one(".entry-content")
-        if not content_div:
-            content_div = soup.select_one("article")
+        # Content: Grid's live article body.  Restrict extraction to paragraphs
+        # inside this container so navigation and adjacent recommendation text
+        # cannot leak into the article body.
+        content_div = soup.select_one(".read__article")
         if not content_div:
             return
 
@@ -76,13 +74,18 @@ class GridScraper(BaseScraper):
         for tag in content_div.find_all(
             ["section", "div", "footer"],
             class_=re.compile(
-                r"related|popular|most|sidebar|share|social|newsletter|ad|subscribe|embed|block_related|td-related|author-box|post-tags|comments|wp-block|bacajuga|bacajuga__|tags__|detail-read__comment",
+                r"related|popular|most|sidebar|share|social|newsletter|advert|(^|[-_ ])ad([-_ ]|$)|subscribe|embed|block_related|td-related|author-box|post-tags|comments|wp-block|bacajuga|bacajuga__|tags__|detail-read__comment",
                 re.IGNORECASE,
             ),
         ):
             tag.extract()
 
-        content = content_div.get_text(separator=" ", strip=True)
+        paragraphs = []
+        for paragraph in content_div.select("p"):
+            text = paragraph.get_text(" ", strip=True)
+            if text:
+                paragraphs.append(text)
+        content = " ".join(paragraphs)
         if not content:
             return
 

--- a/src/newswatch/scrapers/hukumonline.py
+++ b/src/newswatch/scrapers/hukumonline.py
@@ -38,6 +38,17 @@ class HukumonlineScraper(BaseScraper):
         re.IGNORECASE,
     )
     EXCLUDE_RE = re.compile(r"/berita/(?:foto|stories)/", re.IGNORECASE)
+    ARTICLE_ALIAS_RE = re.compile(
+        r"^https?://(?:www\.)?hukumonline\.com/berita/a/([a-z0-9][a-z0-9-]*)/?$",
+        re.IGNORECASE,
+    )
+    PHOTO_RE = re.compile(
+        r"^https?://(?:www\.)?hukumonline\.com/berita/foto/f/([a-z0-9][a-z0-9-]*)/?$",
+        re.IGNORECASE,
+    )
+    LASTMOD_RE = re.compile(
+        r"^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))?$"
+    )
 
     def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
         super().__init__(keywords, concurrency, queue_)
@@ -91,16 +102,46 @@ class HukumonlineScraper(BaseScraper):
             return None
 
         ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-        links = []
-        for url in root.findall(".//sm:url/sm:loc", ns):
-            loc = (url.text or "").strip().rstrip("/")
-            if not loc:
+        records = []
+        for url_node in root.findall(".//sm:url", ns):
+            loc_node = url_node.find("sm:loc", ns)
+            lastmod_node = url_node.find("sm:lastmod", ns)
+            loc = (loc_node.text or "").strip().rstrip("/") if loc_node is not None else ""
+            lastmod = (
+                (lastmod_node.text or "").strip() if lastmod_node is not None else ""
+            )
+            if loc:
+                records.append(
+                    (loc, lastmod if self.LASTMOD_RE.fullmatch(lastmod) else "")
+                )
+
+        photo_slugs = set()
+        for loc, _ in records:
+            match = self.PHOTO_RE.fullmatch(loc)
+            if match:
+                photo_slugs.add(match.group(1).lower())
+
+        dated = []
+        undated = []
+        seen = set()
+        for loc, lastmod in records:
+            if loc in seen or self.EXCLUDE_RE.search(loc):
                 continue
-            if self.EXCLUDE_RE.search(loc):
+            if not self.ARTICLE_RE.match(loc + "/"):
                 continue
-            if self.ARTICLE_RE.match(loc + "/"):
-                links.append(loc)
-        return links or None
+            alias = self.ARTICLE_ALIAS_RE.fullmatch(loc)
+            if alias and alias.group(1).lower() in photo_slugs:
+                continue
+
+            seen.add(loc)
+            candidate = (loc, lastmod)
+            (dated if lastmod else undated).append(candidate)
+
+        dated.sort(key=lambda candidate: candidate[1], reverse=True)
+        links = [loc for loc, _ in dated]
+        links.extend(loc for loc, _ in undated)
+        return links[:10] or None
+
 
     async def get_article(self, link, keyword):
         response_text = await self.fetch(link, headers=self.headers, timeout=30)

--- a/src/newswatch/scrapers/kaltimpost.py
+++ b/src/newswatch/scrapers/kaltimpost.py
@@ -1,14 +1,14 @@
 """
 Kaltim Post (Borneo24) scraper — uses WordPress search with HTML parsing.
 
-https://borneo24.com/?s={keyword}
+https://borneo24.com/search?q={keyword}
 Article pattern: /{slug}
 """
 
 import json
 import logging
 import re
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -22,39 +22,50 @@ class KaltimPostScraper(BaseScraper):
         self.start_date = start_date
         self.continue_scraping = True
         self.max_pages = 10
-        # Article URLs are like /{category}/{slug}
+        # Current canonical article URLs are root-level /{slug} paths.
         self._skip_paths = [
             "/profile/", "/page/", "/category/", "/tag/", "/author/",
         ]
 
     async def build_search_url(self, keyword, page):
-        params = {"s": keyword}
-        if page > 1:
-            params["paged"] = page
-        url = f"{self.base_url}/?{urlencode(params)}"
+        if page != 1:
+            return None
+        url = f"{self.base_url}/search?{urlencode({'q': keyword})}"
         return await self.fetch(url)
 
     def parse_article_links(self, response_text):
+        return self._collect_article_links(
+            response_text, ".post-item h3.title a[href]"
+        )
+
+    def _collect_article_links(self, response_text, selector):
         if not response_text:
             return None
         soup = BeautifulSoup(response_text, "html.parser")
 
-        # Find all links that look like articles (contain dates or category patterns)
         links = set()
-        for a in soup.select("a[href]"):
-            href = a["href"]
-            full_url = urljoin(self.base_url, href) if not href.startswith("http") else href
-            # Must be on borneo24.com and not a navigation/admin link
-            if full_url.startswith(self.base_url):
-                path = full_url.replace(self.base_url, "").strip("/")
-                # Skip non-article paths
-                if any(skip in full_url for skip in self._skip_paths):
-                    continue
-                # Must have a meaningful path (not just domain)
-                if path and "/" in path:
-                    text = a.get_text(strip=True)
-                    if text:  # Has visible text = likely an article link
-                        links.add(full_url)
+        for anchor in soup.select(selector):
+            href = anchor.get("href", "")
+            if not href or not anchor.get_text(strip=True):
+                continue
+
+            full_url = urljoin(f"{self.base_url}/", href)
+            parsed = urlparse(full_url)
+            parts = [part for part in parsed.path.split("/") if part]
+            if (
+                parsed.scheme not in {"http", "https"}
+                or parsed.hostname != "borneo24.com"
+                or parsed.params
+                or parsed.query
+                or parsed.fragment
+                or len(parts) != 1
+                or any(
+                    parts[0].lower() == skip.strip("/").lower()
+                    for skip in self._skip_paths
+                )
+            ):
+                continue
+            links.add(full_url)
         return links or None
 
     async def get_article(self, link, keyword):
@@ -179,19 +190,4 @@ class KaltimPostScraper(BaseScraper):
         return await self.fetch(f"{self.base_url}/page/{page}/")
 
     def parse_latest_article_links(self, response_text):
-        if not response_text:
-            return None
-        soup = BeautifulSoup(response_text, "html.parser")
-        links = set()
-        for a in soup.select("a[href]"):
-            href = a["href"]
-            full_url = urljoin(self.base_url, href) if not href.startswith("http") else href
-            if full_url.startswith(self.base_url):
-                if any(skip in full_url for skip in self._skip_paths):
-                    continue
-                path = full_url.replace(self.base_url, "").strip("/")
-                if path and "/" in path:
-                    text = a.get_text(strip=True)
-                    if text:
-                        links.add(full_url)
-        return links or None
+        return self._collect_article_links(response_text, "a[href]")

--- a/src/newswatch/scrapers/katadata.py
+++ b/src/newswatch/scrapers/katadata.py
@@ -1,9 +1,20 @@
 import json
 import logging
+import re
+from urllib.parse import urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
 from .basescraper import BaseScraper
+
+
+_LATEST_URL = "https://katadata.co.id/indeks"
+_ARTICLE_ID_RE = re.compile(r"[0-9a-fA-F]+")
+_ARTICLE_SLUG_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+_NON_ARTICLE_PATHS = frozenset({
+    "author", "category", "indeks", "kategori", "pencarian", "search",
+    "tag", "tags", "topic", "topik",
+})
 
 
 class KatadataScraper(BaseScraper):
@@ -134,19 +145,39 @@ class KatadataScraper(BaseScraper):
             logging.error(f"Error parsing article {link}: {e}")
 
     async def build_latest_url(self, page):
-        # Katadata search API rejects empty queries — use HTML page instead
+        # Page 2+ uses a POST cursor, which latest mode does not support yet.
         if page > 1:
-            return await self.fetch(f"{self.base_url}/berita/indeks?page={page}")
-        return await self.fetch(f"{self.base_url}/berita/indeks")
+            return None
+        return await self.fetch(_LATEST_URL)
 
     def parse_latest_article_links(self, response_text):
         if not response_text:
             return None
         soup = BeautifulSoup(response_text, "html.parser")
-        links = set()
-        for a in soup.select("a[href]"):
-            href = a.get("href", "")
-            if "/berita/" in href and "/read/" in href:
-                full_url = href if href.startswith("http") else f"https://www.{self.base_url}{href}"
-                links.add(full_url)
+        links = {
+            link
+            for anchor in soup.select("article.article--berita a[href]")
+            if (link := self._canonical_article_url(anchor.get("href", "")))
+        }
         return links or None
+
+    @staticmethod
+    def _canonical_article_url(href):
+        if not isinstance(href, str) or not href.strip():
+            return None
+        parsed = urlparse(urljoin(f"{_LATEST_URL}/", href.strip()))
+        if (
+            parsed.scheme not in {"http", "https"}
+            or parsed.netloc.lower() != "katadata.co.id"
+            or parsed.params
+        ):
+            return None
+        parts = [part for part in parsed.path.split("/") if part]
+        if (
+            len(parts) < 2
+            or any(part.lower() in _NON_ARTICLE_PATHS for part in parts[:-2])
+            or not _ARTICLE_ID_RE.fullmatch(parts[-2])
+            or not _ARTICLE_SLUG_RE.fullmatch(parts[-1])
+        ):
+            return None
+        return f"https://katadata.co.id/{'/'.join(parts)}"

--- a/src/newswatch/scrapers/kumparan.py
+++ b/src/newswatch/scrapers/kumparan.py
@@ -5,6 +5,7 @@ No search API available, but sitemaps provide article URLs
 that can be filtered by keyword presence.
 """
 
+import json
 import logging
 import xml.etree.ElementTree as ET
 
@@ -73,8 +74,7 @@ class KumparanScraper(BaseScraper):
             if not title:
                 return
 
-            meta_date = soup.find("meta", {"property": "article:published_time"})
-            publish_date_str = meta_date.get("content", "") if meta_date else ""
+            publish_date = self._extract_date(soup)
 
             content_div = soup.select_one("div.article-content") or soup.select_one("article")
             if not content_div:
@@ -90,9 +90,8 @@ class KumparanScraper(BaseScraper):
             meta_author = soup.find("meta", {"name": "author"})
             author = meta_author.get("content", "Unknown") if meta_author else "Unknown"
 
-            publish_date = self.parse_date(publish_date_str)
             if not publish_date:
-                logging.debug("Kumparan date parse failed | url: %s | date: %r", link, publish_date_str[:50])
+                logging.debug("Kumparan date parse failed | url: %s", link)
                 return
 
             if self.start_date and publish_date < self.start_date:
@@ -118,6 +117,47 @@ class KumparanScraper(BaseScraper):
             await self.queue_.put(item)
         except Exception as e:
             logging.error("Error parsing article %s: %s", link, e)
+
+    def _extract_date(self, soup):
+        meta_date = soup.find("meta", {"property": "article:published_time"})
+        if meta_date and meta_date.get("content"):
+            parsed = self.parse_date(meta_date["content"])
+            if parsed:
+                return parsed
+
+        for script in soup.find_all("script", type="application/ld+json"):
+            raw = script.string or script.get_text()
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for node in self._json_ld_nodes(payload):
+                node_type = node.get("@type")
+                is_news_article = node_type == "NewsArticle" or (
+                    isinstance(node_type, list) and "NewsArticle" in node_type
+                )
+                if not is_news_article:
+                    continue
+                date_published = node.get("datePublished")
+                if not isinstance(date_published, str):
+                    continue
+                parsed = self.parse_date(date_published)
+                if parsed:
+                    return parsed
+        return None
+
+    @staticmethod
+    def _json_ld_nodes(payload):
+        candidates = payload if isinstance(payload, list) else (payload,)
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            graph = candidate.get("@graph")
+            if isinstance(graph, list):
+                yield from (node for node in graph if isinstance(node, dict))
+            yield candidate
 
     async def build_search_url(self, keyword, page):
         return None

--- a/src/newswatch/scrapers/ntvnews.py
+++ b/src/newswatch/scrapers/ntvnews.py
@@ -1,0 +1,458 @@
+"""
+NTVNews.id (www.ntvnews.id) scraper — single Google News sitemap driven.
+
+Verified endpoints:
+    news sitemap: https://www.ntvnews.id/sitemap-news.xml
+    article:      https://www.ntvnews.id/<category>/<8-digit-id>/<slug>
+
+The site's /search/?q= endpoint is disallowed by robots.txt, so search uses
+the bounded news sitemap set instead. Sitemap entries carry <news:title> plus
+<news:publication_date> and a <keywords> element; search applies every-token
+matching to the title only, in keeping with native search rank by headline.
+Latest mode walks the same sitemap without keyword filtering.
+
+Publisher legitimacy (Dewan Pers verified 2024-11-25) is validated separately;
+this scraper only consumes the public news sitemap and article markup.
+"""
+import contextvars
+import json
+import logging
+import re
+import xml.etree.ElementTree as ET
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from .basescraper import BaseScraper
+
+_SM_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_NEWS_NS = "http://www.google.com/schemas/sitemap-news/0.9"
+_SITEMAP_NSMAP = {"sm": _SM_NS, "news": _NEWS_NS}
+
+_BASE_URL = "https://www.ntvnews.id"
+_NEWS_SITEMAP_URL = f"{_BASE_URL}/sitemap-news.xml"
+
+_current_keyword: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "ntvnews_current_keyword", default=""
+)
+
+_CANONICAL_HOSTS = {"ntvnews.id", "www.ntvnews.id"}
+_EXCLUDED_CATEGORIES = {
+    "admin", "amp", "author", "category", "feed", "page", "search", "tag", "wp-admin", "wp-content"
+}
+
+_NOISE_CLASS_RE = re.compile(
+    r"baca[_-]juga|berita[_-]terkait|berita[_-]rekomendasi|share|"
+    r"social|sidebar|footer|nav|promo|ads|advert|comment|newsletter|"
+    r"recommended|related|tag|topic",
+    re.IGNORECASE,
+)
+
+
+def _normalize(text):
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _keyword_tokens(keyword):
+    return [tok for tok in re.split(r"\W+", (keyword or "").lower()) if len(tok) > 1]
+
+
+def _matches_all_tokens(haystack, tokens):
+    if not tokens:
+        return True
+    if not haystack:
+        return False
+    return all(re.search(rf"\b{re.escape(tok)}\b", haystack) for tok in tokens)
+
+
+def _to_naive(value):
+    """Strip tz info for the queue payload; dateparser may return aware datetimes."""
+    if value is None:
+        return None
+    if value.tzinfo is not None:
+        try:
+            return value.replace(tzinfo=None)
+        except (AttributeError, ValueError):
+            return value
+    return value
+
+
+def _canonical_article_url(url):
+    """Normalize same-site article URLs and reject non-article surfaces."""
+    if not isinstance(url, str) or not url.strip():
+        return None
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() not in _CANONICAL_HOSTS:
+        return None
+    if parsed.query or parsed.fragment:
+        return None
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 3:
+        return None
+    category, article_id, slug = parts
+    if category.lower() in _EXCLUDED_CATEGORIES:
+        return None
+    if not re.fullmatch(r"[a-z][a-z0-9-]*", category, re.IGNORECASE):
+        return None
+    if not re.fullmatch(r"\d{8}", article_id):
+        return None
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug, re.IGNORECASE):
+        return None
+    return f"{_BASE_URL}/{category}/{article_id}/{slug}"
+
+
+class NTVNewsScraper(BaseScraper):
+    """NTVNews.id scraper driven by the single Google News sitemap."""
+
+    BASE_URL = _BASE_URL
+    SITEMAP_URL = _NEWS_SITEMAP_URL
+    SOURCE_LABEL = "ntvnews.id"
+
+    @property
+    def _current_keyword(self):
+        return _current_keyword.get()
+
+    @_current_keyword.setter
+    def _current_keyword(self, value):
+        _current_keyword.set(value)
+    MAX_ARTICLES_PER_QUERY = 50
+
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
+        super().__init__(keywords, concurrency, queue_)
+        self.base_url = self.BASE_URL
+        self.start_date = start_date
+        self.max_latest_pages = 1
+        self._current_keyword = self.keywords[0] if len(self.keywords) == 1 else ""
+        self.headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/130.0.0.0 Safari/537.36"
+            ),
+            "Accept": (
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            ),
+            "Accept-Language": "id-ID,id;q=0.9,en-US;q=0.8,en;q=0.7",
+        }
+
+    # ------------------------------------------------------------------
+    # Sitemap discovery
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_sitemap_xml(response_text):
+        """Return list of (loc, news_title, publication_date) tuples from the
+        Google News sitemap urlset.
+
+        The News sitemap is bounded: every <url> is a recent news article, so
+        preservation of sitemap order is the natural latest-ranking order.
+        """
+        if not response_text:
+            return []
+        head = response_text.lstrip()[:64].lower()
+        if not head.startswith("<?xml") and "<urlset" not in head:
+            return []
+        try:
+            root = ET.fromstring(response_text)
+        except ET.ParseError as e:
+            logging.error("NTVNews sitemap parse error: %s", e)
+            return []
+        if root.tag != f"{{{_SM_NS}}}urlset":
+            return []
+
+        entries = []
+        for url in root.findall("sm:url", _SITEMAP_NSMAP):
+            loc_el = url.find("sm:loc", _SITEMAP_NSMAP)
+            loc = (loc_el.text or "").strip() if loc_el is not None else ""
+            if not loc:
+                continue
+            canonical = _canonical_article_url(loc)
+            if not canonical:
+                continue
+            title = ""
+            news_el = url.find("news:news", _SITEMAP_NSMAP)
+            if news_el is not None:
+                title_el = news_el.find("news:title", _SITEMAP_NSMAP)
+                if title_el is not None and title_el.text:
+                    title = title_el.text.strip()
+            date_text = ""
+            if news_el is not None:
+                date_el = news_el.find("news:publication_date", _SITEMAP_NSMAP)
+                if date_el is not None and date_el.text:
+                    date_text = date_el.text.strip()
+            entries.append((canonical, title, date_text))
+        return entries
+
+    async def _fetch_sitemap_entries(self, sitemap_url):
+        text = await self.fetch(sitemap_url, headers=self.headers, timeout=30)
+        if not text:
+            return []
+        return self._parse_sitemap_xml(text)
+
+    # ------------------------------------------------------------------
+    # Search path: keyword-filtered sitemap entries (title-only)
+    # ------------------------------------------------------------------
+    async def build_search_url(self, keyword, page):
+        self._current_keyword = keyword or ""
+        if page != 1:
+            return None
+        return await self._fetch_sitemap_entries(self.SITEMAP_URL)
+
+    def parse_article_links(self, response_text_or_entries):
+        """Accept either raw XML (legacy) or pre-parsed list of (loc, title, date)."""
+        if not response_text_or_entries:
+            return None
+        if isinstance(response_text_or_entries, str):
+            entries = self._parse_sitemap_xml(response_text_or_entries)
+        else:
+            entries = response_text_or_entries
+
+        tokens = _keyword_tokens(self._current_keyword)
+        links = []
+        seen = set()
+        for loc, title, _date in entries:
+            canonical = _canonical_article_url(loc)
+            if not canonical:
+                continue
+            haystack = _normalize(title)
+            if not _matches_all_tokens(haystack, tokens):
+                continue
+            if canonical not in seen:
+                links.append(canonical)
+                seen.add(canonical)
+            if len(links) >= self.MAX_ARTICLES_PER_QUERY:
+                break
+        return links or None
+
+    # ------------------------------------------------------------------
+    # Latest path: unfiltered sitemap entries
+    # ------------------------------------------------------------------
+    async def build_latest_url(self, page):
+        if page != 1:
+            return None
+        return await self._fetch_sitemap_entries(self.SITEMAP_URL)
+
+    def parse_latest_article_links(self, response_text_or_entries):
+        if not response_text_or_entries:
+            return None
+        if isinstance(response_text_or_entries, str):
+            entries = self._parse_sitemap_xml(response_text_or_entries)
+        else:
+            entries = response_text_or_entries
+
+        links = []
+        seen = set()
+        for loc, _title, _date in entries:
+            canonical = _canonical_article_url(loc)
+            if not canonical:
+                continue
+            if canonical not in seen:
+                links.append(canonical)
+                seen.add(canonical)
+        return links or None
+
+    # ------------------------------------------------------------------
+    # Article fetch + extraction
+    # ------------------------------------------------------------------
+    async def get_article(self, link, keyword):
+        canonical = _canonical_article_url(link)
+        if not canonical:
+            logging.debug("NTVNews rejecting non-canonical URL: %s", link)
+            return
+
+        response_text = await self.fetch(canonical, headers=self.headers, timeout=30)
+        if not response_text:
+            logging.warning("NTVNews no response for %s", link)
+            return
+
+        soup = BeautifulSoup(response_text, "html.parser")
+
+        title = self._extract_title(soup)
+        if not title:
+            return
+
+        publish_date = self._extract_date(soup)
+        if not publish_date:
+            return
+        publish_date = _to_naive(publish_date)
+
+        if self.start_date and publish_date < self._normalize_start(self.start_date):
+            self.continue_scraping = False
+            return
+
+        author = self._extract_author(soup)
+        category = self._extract_category(soup, link)
+        content = self._extract_content(soup)
+        if not content:
+            return
+
+        item = {
+            "title": title,
+            "publish_date": publish_date,
+            "author": author,
+            "content": content,
+            "keyword": keyword,
+            "category": category,
+            "source": self.SOURCE_LABEL,
+            "link": canonical,
+        }
+        await self.queue_.put(item)
+
+    @staticmethod
+    def _extract_title(soup):
+        h1 = soup.select_one("h1.title")
+        if h1:
+            value = h1.get_text(" ", strip=True)
+            if value:
+                return value
+        meta = soup.find("meta", {"property": "og:title"})
+        if meta and meta.get("content"):
+            value = meta["content"].strip()
+            if value:
+                return value
+        h1 = soup.select_one("h1")
+        if h1:
+            value = h1.get_text(strip=True)
+            if value:
+                return value
+        if soup.title and soup.title.string:
+            value = soup.title.string.strip()
+            if value:
+                return value
+        return ""
+
+    def _extract_date(self, soup):
+        # JSON-LD NewsArticle first; trusted schema.org metadata.
+        for script in soup.find_all("script", {"type": "application/ld+json"}):
+            payload = self._parse_ld_json(script.string)
+            if not payload:
+                continue
+            for node in self._iter_ld_nodes(payload):
+                dt = node.get("datePublished") or node.get("dateCreated")
+                if dt:
+                    parsed = self.parse_date(dt)
+                    if parsed:
+                        return parsed
+
+        # visible date strings — NTV often renders DD/MM/YYYY HH:MM
+        text = soup.get_text(" ", strip=True)
+        for pattern in (
+            r"\b\d{2}/\d{2}/\d{4}\s+\d{1,2}:\d{2}\b",
+            r"\b\d{2}/\d{2}/\d{4}\b",
+            r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}",
+        ):
+            m = re.search(pattern, text)
+            if m:
+                parsed = self.parse_date(m.group(0))
+                if parsed:
+                    return parsed
+        return None
+
+    @staticmethod
+    def _parse_ld_json(raw):
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    @staticmethod
+    def _iter_ld_nodes(payload):
+        if payload is None:
+            return
+        nodes = payload if isinstance(payload, list) else [payload]
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            graph = node.get("@graph") or [node]
+            for entry in graph:
+                if isinstance(entry, dict):
+                    yield entry
+
+    def _extract_author(self, soup):
+        candidates = []
+        for block in soup.select(".penulis"):
+            name = block.select_one(".nama")
+            if not name:
+                continue
+            value = name.get_text(" ", strip=True)
+            role = " ".join(
+                node.get_text(" ", strip=True) for node in block.select(".detail")
+            ).casefold()
+            if value:
+                candidates.append((value, role))
+        for value, role in candidates:
+            if "penulis" in role:
+                return value
+
+        for script in soup.find_all("script", {"type": "application/ld+json"}):
+            payload = self._parse_ld_json(script.string)
+            for node in self._iter_ld_nodes(payload):
+                author = node.get("author")
+                authors = author if isinstance(author, list) else [author]
+                for entry in authors:
+                    if isinstance(entry, dict) and entry.get("name"):
+                        return entry["name"].strip()
+                    if isinstance(entry, str) and entry.strip():
+                        return entry.strip()
+
+        for value, role in candidates:
+            if "editor" in role:
+                return value
+        if candidates:
+            return candidates[0][0]
+        meta = soup.find("meta", {"name": "author"})
+        return meta["content"].strip() if meta and meta.get("content") else "Unknown"
+
+    def _extract_category(self, soup, link):
+        breadcrumbs = [
+            anchor.get_text(" ", strip=True)
+            for anchor in soup.select(".breadcrumb a, nav.breadcrumb a, ol.breadcrumb a")
+        ]
+        categories = [value for value in breadcrumbs if value and value.casefold() != "home"]
+        if categories:
+            return categories[-1]
+        for script in soup.find_all("script", {"type": "application/ld+json"}):
+            payload = self._parse_ld_json(script.string)
+            for node in self._iter_ld_nodes(payload):
+                section = node.get("articleSection")
+                if isinstance(section, str) and section.strip():
+                    return section.strip()
+        parts = [part for part in urlparse(link).path.split("/") if part]
+        return parts[0] if parts else "news"
+
+    def _extract_content(self, soup):
+        body = soup.select_one(".article-content")
+        if not body:
+            return ""
+
+        for tag in list(body.find_all(["script", "style", "iframe", "noscript"])):
+            tag.extract()
+        for tag in list(body.find_all(attrs={"class": _NOISE_CLASS_RE})):
+            tag.extract()
+        for tag in list(body.select(".baca-juga, .baca_juga, #relatedNews, .berita--terkait")):
+            tag.extract()
+        for p in list(body.find_all("p")):
+            if re.match(r"^\s*(?:baca\s+juga|simak\s+juga)\s*:", p.get_text(" ", strip=True), re.IGNORECASE):
+                p.extract()
+
+        paragraphs = []
+        for p in body.find_all("p"):
+            text = p.get_text(" ", strip=True)
+            if len(text) >= 20:
+                paragraphs.append(text)
+        content = " ".join(paragraphs).strip()
+        if content:
+            return content
+        return ""
+
+    @staticmethod
+    def _normalize_start(value):
+        if value is None:
+            return None
+        if hasattr(value, "tzinfo") and value.tzinfo is not None:
+            try:
+                return value.replace(tzinfo=None)
+            except (AttributeError, ValueError):
+                return value
+        return value

--- a/src/newswatch/scrapers/nusabali.py
+++ b/src/newswatch/scrapers/nusabali.py
@@ -15,8 +15,8 @@ https://www.nusabali.com/berita/225365/pria-mabuk-di-desa-keramas-diamankan-poli
             (preceded by "Penulis : ")
 - category: .breadcrumb span.article-category[itemprop="articleSection"];
             falls back to "Unknown"
-- body:     <p> children of div.entry-content[itemprop="articleBody"];
-            strips related/nav/share/sidebar/terkait blocks before extraction.
+- body:     .entry-box[itemprop="articleBody"], scoped to its inner
+            .entry-content when present; strips related/nav/share/sidebar blocks.
 """
 
 import logging
@@ -177,11 +177,12 @@ class NusaBaliScraper(BaseScraper):
 
     @staticmethod
     def _extract_content(soup):
-        body = soup.select_one("div.entry-content[itemprop='articleBody']")
+        body = soup.select_one(".entry-box[itemprop='articleBody']")
         if not body:
             return ""
+        content = body.select_one(".entry-content") or body
         # Strip nav/share/sidebar blocks before collecting paragraphs.
-        for tag in body.find_all(
+        for tag in content.find_all(
             [
                 "aside",
                 "nav",
@@ -193,11 +194,11 @@ class NusaBaliScraper(BaseScraper):
             ]
         ):
             tag.decompose()
-        for tag in body.find_all(True, {"class": _NAV_CLASS_RE}):
+        for tag in content.find_all(True, {"class": _NAV_CLASS_RE}):
             tag.decompose()
 
         paragraphs = []
-        for p in body.find_all("p"):
+        for p in content.find_all("p"):
             text = p.get_text(" ", strip=True)
             if text:
                 paragraphs.append(text)

--- a/src/newswatch/scrapers/voi.py
+++ b/src/newswatch/scrapers/voi.py
@@ -7,11 +7,17 @@ https://voi.id/en/artikel/cari?q={keyword}
 import json
 import logging
 import re
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
 from .basescraper import BaseScraper
+
+
+_ARTICLE_CATEGORY_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+_NON_ARTICLE_CATEGORIES = frozenset({
+    "artikel", "cari", "index", "indeks", "search",
+})
 
 
 class VOIScraper(BaseScraper):
@@ -37,12 +43,7 @@ class VOIScraper(BaseScraper):
         if no_result:
             return None
 
-        links = set()
-        for title_elem in soup.select(".section-item-title a"):
-            href = title_elem.get("href", "")
-            if href:
-                links.add(href)
-        return links or None
+        return self._collect_article_links(soup)
 
     async def get_article(self, link, keyword):
         response_text = await self.fetch(link)
@@ -171,11 +172,33 @@ class VOIScraper(BaseScraper):
     def parse_latest_article_links(self, response_text):
         if not response_text:
             return None
-        soup = BeautifulSoup(response_text, "html.parser")
-        links = set()
-        for title_elem in soup.select(".section-item-title a"):
-            href = title_elem.get("href", "")
-            if href and "/en/artikel/" in href and "/cari" not in href and "/indeks" not in href:
-                # Filter to article pages only, exclude search/index listing pages
-                links.add(href)
+        return self._collect_article_links(BeautifulSoup(response_text, "html.parser"))
+
+    def _collect_article_links(self, soup):
+        links = {
+            link
+            for anchor in soup.select(".section-item-title a[href]")
+            if (link := self._canonical_article_url(anchor.get("href", "")))
+        }
         return links or None
+
+    def _canonical_article_url(self, href):
+        if not isinstance(href, str) or not href.strip():
+            return None
+        parsed = urlparse(urljoin(f"{self.base_url}/", href.strip()))
+        if (
+            parsed.scheme not in {"http", "https"}
+            or parsed.netloc.lower() != "voi.id"
+            or parsed.params
+        ):
+            return None
+        parts = [part for part in parsed.path.split("/") if part]
+        if (
+            len(parts) != 3
+            or parts[0] != "en"
+            or parts[1] in _NON_ARTICLE_CATEGORIES
+            or not _ARTICLE_CATEGORY_RE.fullmatch(parts[1])
+            or not parts[2].isdigit()
+        ):
+            return None
+        return f"{self.base_url}/{'/'.join(parts)}"

--- a/tests/test_basescraper.py
+++ b/tests/test_basescraper.py
@@ -24,3 +24,25 @@ async def test_basescraper_initialization_normalizes_keywords_and_keeps_queue():
 async def test_basescraper_initialization_empty_keywords_yield_empty_list():
     scraper = DummyScraper("")
     assert scraper.keywords == []
+
+
+class _PaginationScraper(BaseScraper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.visited_pages: list[int] = []
+
+    async def build_search_url(self, keyword, page):
+        self.visited_pages.append(page)
+        return f"page-{page}"
+
+    def parse_article_links(self, response_text):
+        return [f"https://example.com/{response_text}"]
+
+    async def get_article(self, link, keyword):
+        pass
+
+
+async def test_fetch_search_results_with_max_pages_two_stops_after_page_two():
+    scraper = _PaginationScraper("ihsg", queue_=asyncio.Queue(), max_pages=2)
+    await scraper.fetch_search_results("ihsg")
+    assert scraper.visited_pages == [1, 2]

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -210,8 +210,8 @@ async def test_scraper_fetch_latest(slug: str, scraper_class: type) -> None:
         keywords=SCRAPERS[slug].smoke_keyword,
         queue_=queue,
     )
-    if hasattr(scraper, "max_pages"):
-        scraper.max_pages = 2
+    if hasattr(scraper, "max_latest_pages"):
+        scraper.max_latest_pages = 2
 
     consumer_task = asyncio.create_task(item_consumer(queue))
 

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -77,7 +77,7 @@ from newswatch.scrapers.wartaekonomi import WartaEkonomiScraper
 from newswatch.scrapers.idxchannel import IDXChannelScraper
 from newswatch.scrapers.infobanknews import InfobanknewsScraper
 from newswatch.scrapers.indopolitika import IndopolitikaScraper
-
+from newswatch.scrapers.ntvnews import NTVNewsScraper
 
 # ── Shared offline test scaffolding ────────────────────────────────────────
 
@@ -3184,3 +3184,384 @@ class TestIndopolitikaFocus:
 
         assert s.queue_.qsize() == 0
         assert s.continue_scraping is False
+
+
+
+# ── 13. NTVNews: news-sitemap discovery, title-only keyword gate, extraction ─
+
+
+_NTV_NS_SM = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_NTV_NS_NEWS = "http://www.google.com/schemas/sitemap-news/0.9"
+_NTV_SITEMAP_URL = "https://www.ntvnews.id/sitemap-news.xml"
+
+
+def _ntv_news_sitemap_xml(entries: list[tuple[str, str]]) -> str:
+    """Render a Google-news sitemap. Each tuple is (loc, news:title)."""
+    body = "".join(
+        f"<url><loc>{loc}</loc>"
+        f"<news:news><news:title><![CDATA[{title}]]></news:title>"
+        f"</news:news></url>"
+        for loc, title in entries
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<urlset xmlns="{_NTV_NS_SM}" xmlns:news="{_NTV_NS_NEWS}">'
+        f"{body}</urlset>"
+    )
+
+
+def _ntv_article_html(
+    *,
+    title: str = "NTV test headline",
+    writer: str = "NTV Writer",
+    editor: str = "NTV Editor",
+    date_iso: str = "2026-07-12T10:00:00+07:00",
+    section: str = "Nasional",
+    breadcrumb_label: str = "Nasional",
+    paragraphs: tuple[str, ...] = (
+        "NTV lead paragraph included by the article-descendant extractor.",
+        "NTV second paragraph continuing the joined article body.",
+    ),
+    extra_blocks: str = "",
+) -> str:
+    ld_payload = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        "datePublished": date_iso,
+        "articleSection": section,
+        "author": {"@type": "Person", "name": writer or editor},
+    })
+    paras = "".join(f"<p>{p}</p>" for p in paragraphs)
+    return (
+        '<!doctype html><html><head>'
+        f'<script type="application/ld+json">{ld_payload}</script>'
+        '</head><body>'
+        '<nav class="breadcrumb">'
+        f'<a href="/">Home</a> <a href="/news">{breadcrumb_label}</a>'
+        '</nav>'
+        '<article>'
+        f'<h1 class="title">{title}</h1>'
+        '<div class="penulis">'
+        f'<span class="nama">{writer}</span><span class="detail">Penulis</span>'
+        '</div>'
+        '<div class="penulis">'
+        f'<span class="nama">{editor}</span><span class="detail">Editor</span>'
+        '</div>'
+        '<div class="article-content">'
+        f'{paras}'
+        f'{extra_blocks}'
+        '</div>'
+        '</article>'
+        '</body></html>'
+    )
+
+
+class TestNTVNewsSearchOnePageAndKeywordGate:
+    """NTV search-mode parser:
+    - hits ``/sitemap-news.xml`` once on page 1, short-circuits on later pages
+    - canonicalizes /<category>/<8-digit-id>/<slug> on same host only,
+      dropping query/fragment/nested/taxonomy and dedupes
+    - filters every keyword token against ``<news:title>`` ONLY (URL or
+      metadata alone MUST NOT satisfy the gate).
+    """
+
+    BASE = "https://www.ntvnews.id"
+    KEYWORDS = "makan bergizi"
+
+    def _xml(self, entries: list[tuple[str, str]]) -> str:
+        return _ntv_news_sitemap_xml(entries)
+
+    @pytest.mark.asyncio
+    async def test_search_fetches_sitemap_once_and_short_circuits_later_pages(self):
+        s = NTVNewsScraper(keywords=self.KEYWORDS, queue_=asyncio.Queue())
+        stub = _attach_fetch(s, {_NTV_SITEMAP_URL: "<xml/>"})
+
+        result = await s.build_search_url(self.KEYWORDS, 1)
+        assert isinstance(result, list) or isinstance(result, str)
+        assert stub.calls and stub.calls[-1][0] == _NTV_SITEMAP_URL
+
+        # Page 2 / 0 must NOT fetch again.
+        calls_after_page1 = len(stub.calls)
+        assert await s.build_search_url(self.KEYWORDS, 2) is None
+        assert await s.build_search_url(self.KEYWORDS, 0) is None
+        assert len(stub.calls) == calls_after_page1
+
+    def test_search_parser_dedupes_and_rejects_off_pattern_urls(self):
+        s = NTVNewsScraper(keywords=self.KEYWORDS, queue_=asyncio.Queue())
+        xml = self._xml([
+            ("https://ntvnews.id/nasional/12345678/makan-bergizi-untuk-anak",
+             "Makan Bergizi title"),
+            # Duplicate of canonical → must be deduped.
+            ("https://www.ntvnews.id/nasional/12345678/makan-bergizi-untuk-anak/",
+             "Makan Bergizi title duplicate"),
+            # Off-host → reject.
+            ("https://other.example.com/nasional/12345678/abc/", "other host"),
+            # Wrong id length → reject (not 8 digits).
+            ("https://www.ntvnews.id/nasional/1234567/abc/", "seven digit"),
+            # Non-digit id → reject.
+            ("https://www.ntvnews.id/nasional/abcdefgh/abc/", "non-digit id"),
+            # No slug after id → reject.
+            ("https://www.ntvnews.id/nasional/12345678/", "no slug"),
+            # Nested slug (extra segment) → reject.
+            ("https://www.ntvnews.id/nasional/12345678/foo/bar/", "nested"),
+            # Taxonomy surfaces → reject.
+            ("https://www.ntvnews.id/tag/12345678/foo/", "tag surface"),
+            ("https://www.ntvnews.id/author/12345678/foo/", "author surface"),
+            ("https://www.ntvnews.id/category/nasional/12345678/foo/", "category surface"),
+            # Query string → reject.
+            ("https://www.ntvnews.id/nasional/12345678/foo/?utm=zz", "with query"),
+            # Fragment → reject.
+            ("https://www.ntvnews.id/nasional/12345678/foo/#section", "with fragment"),
+        ])
+        s._current_keyword = self.KEYWORDS
+        links = s.parse_article_links(xml)
+        assert links == [
+            "https://www.ntvnews.id/nasional/12345678/makan-bergizi-untuk-anak",
+        ]
+
+    def test_search_filter_requires_title_match_url_alone_is_not_enough(self):
+        """The URL contains every token but the title contains none → reject.
+        Pin: keyword tokens are checked against ``<news:title>`` only."""
+        s = NTVNewsScraper(keywords=self.KEYWORDS, queue_=asyncio.Queue())
+        xml = self._xml([
+            ("https://www.ntvnews.id/nasional/12345678/makan-bergizi-untuk-anak/",
+             "Unrelated headline about something else entirely"),
+        ])
+        s._current_keyword = self.KEYWORDS
+        assert s.parse_article_links(xml) is None
+
+    def test_search_filter_requires_every_token_partial_title_match_is_rejected(self):
+        """Title contains one of the two tokens but not the other → reject."""
+        s = NTVNewsScraper(keywords=self.KEYWORDS, queue_=asyncio.Queue())
+        xml = self._xml([
+            ("https://www.ntvnews.id/nasional/12345678/cerita-makan/",
+             "Cerita Makan di Pasar Tradisional"),
+        ])
+        s._current_keyword = self.KEYWORDS
+        assert s.parse_article_links(xml) is None
+
+    def test_search_filter_keeps_full_token_match_against_title(self):
+        s = NTVNewsScraper(keywords=self.KEYWORDS, queue_=asyncio.Queue())
+        xml = self._xml([
+            ("https://www.ntvnews.id/nasional/12345678/program-makan-bergizi/",
+             "Program Makan Bergizi Gratis Resmi Diluncurkan"),
+        ])
+        s._current_keyword = self.KEYWORDS
+        links = s.parse_article_links(xml)
+        assert links == [
+            "https://www.ntvnews.id/nasional/12345678/program-makan-bergizi",
+        ]
+
+
+class TestNTVNewsLatestUnfiltered:
+    """NTV latest-mode parser returns every canonical entry from
+    ``/sitemap-news.xml`` without applying the title-only keyword gate.
+    Off-pattern URLs are still rejected and dedupe still applies.
+    """
+
+    BASE = "https://www.ntvnews.id"
+
+    def test_latest_returns_canonical_entries_without_keyword_filter(self):
+        s = NTVNewsScraper(keywords="makan bergizi", queue_=asyncio.Queue())
+        xml = _ntv_news_sitemap_xml([
+            ("https://www.ntvnews.id/nasional/12345678/program-makan-bergizi/",
+             "Makan Bergizi title"),
+            ("https://www.ntvnews.id/internasional/87654321/ekonomi-asia/",
+             "Ekonomi Asia"),
+            ("https://www.ntvnews.id/olahraga/11223344/liga-champions/",
+             "Liga Champions"),
+        ])
+        links = s.parse_latest_article_links(xml)
+        assert links == [
+            "https://www.ntvnews.id/nasional/12345678/program-makan-bergizi",
+            "https://www.ntvnews.id/internasional/87654321/ekonomi-asia",
+            "https://www.ntvnews.id/olahraga/11223344/liga-champions",
+        ]
+
+    def test_latest_dedupes_and_rejects_off_pattern_entries(self):
+        s = NTVNewsScraper(keywords="makan bergizi", queue_=asyncio.Queue())
+        xml = _ntv_news_sitemap_xml([
+            ("https://www.ntvnews.id/nasional/12345678/program-makan-bergizi/",
+             "title A"),
+            ("https://www.ntvnews.id/nasional/12345678/program-makan-bergizi/",
+             "title B duplicate"),
+            ("https://other.example.com/nasional/12345678/abc/", "off host"),
+            ("https://www.ntvnews.id/tag/12345678/foo/", "tag surface"),
+            ("https://www.ntvnews.id/nasional/12345/abc/", "short id"),
+        ])
+        links = s.parse_latest_article_links(xml)
+        assert links == [
+            "https://www.ntvnews.id/nasional/12345678/program-makan-bergizi",
+        ]
+
+    def test_latest_parser_rejects_non_xml(self):
+        s = NTVNewsScraper(keywords="makan bergizi", queue_=asyncio.Queue())
+        cloudflare = (
+            "<!doctype html><html><head><title>Just a moment...</title>"
+            "</head><body>Please enable JavaScript to continue.</body></html>"
+        )
+        assert s.parse_latest_article_links(cloudflare) is None
+
+    def test_latest_parser_rejects_malformed_xml(self):
+        s = NTVNewsScraper(keywords="makan bergizi", queue_=asyncio.Queue())
+        assert s.parse_latest_article_links(
+            "<?xml version='1.0'?><urlset><url><loc>oops</loc></url"
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_latest_fetches_sitemap_once_for_page_one(self):
+        s = NTVNewsScraper(keywords="makan bergizi", queue_=asyncio.Queue())
+        stub = _attach_fetch(s, {_NTV_SITEMAP_URL: "<xml/>"})
+        await s.build_latest_url(1)
+        assert stub.calls and stub.calls[-1][0] == _NTV_SITEMAP_URL
+        # Page != 1 stops without further fetch.
+        before = len(stub.calls)
+        assert await s.build_latest_url(2) is None
+        assert len(stub.calls) == before
+
+
+class TestNTVNewsArticleExtraction:
+    """NTV article extraction contract:
+    - ``h1.title`` is the title
+    - JSON-LD ``datePublished`` drives publish_date; timezone is stripped
+    - breadcrumb leaf (last non-Home anchor) drives category; JSON-LD may
+      also feed category
+    - ``.article-content`` is the body container
+    - writer preferred over editor from visible role-labelled bylines
+    - missing critical data (title / date / content) drops the article
+    - queue item has exactly the eight standard keys in the documented order
+    """
+
+    BASE = "https://www.ntvnews.id"
+    SOURCE = "ntvnews.id"
+    LINK = f"{BASE}/nasional/12345678/program-makan-bergizi"
+    KEYWORD = "makan bergizi"
+
+    @pytest.mark.asyncio
+    async def test_full_schema_writer_wins_over_editor(self):
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: _ntv_article_html()})
+        await s.get_article(self.LINK, self.KEYWORD)
+
+        assert s.queue_.qsize() == 1
+        item = await s.queue_.get()
+        assert list(item.keys()) == list(_QUEUE_KEYS)
+        assert item["title"] == "NTV test headline"
+        assert item["author"] == "NTV Writer"  # writer beats editor
+        assert item["category"] == "Nasional"  # breadcrumb leaf (or JSON-LD fallback)
+        assert item["source"] == self.SOURCE
+        assert item["keyword"] == self.KEYWORD
+        assert item["link"] == self.LINK
+        # JSON-LD ``datePublished`` → naive datetime (tz stripped).
+        assert item["publish_date"] == datetime(2026, 7, 12, 10, 0, 0)
+        assert item["publish_date"].tzinfo is None
+        # Real paragraphs preserved.
+        assert "NTV lead paragraph" in item["content"]
+        assert "NTV second paragraph" in item["content"]
+
+    @pytest.mark.asyncio
+    async def test_only_editor_present_falls_back_to_editor(self):
+        """With no writer, the editor supplies the visible byline."""
+        html = _ntv_article_html(writer="", editor="NTV Editor")
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        item = s.queue_.get_nowait()
+        assert item["author"] == "NTV Editor"
+
+    @pytest.mark.asyncio
+    async def test_breadcrumb_leaf_drives_category(self):
+        """No JSON-LD section → last non-Home breadcrumb anchor."""
+        # Author is stripped from JSON-LD so the writer/editor HTML fallback
+        # path still produces a name (writer preferred).
+        html = _ntv_article_html(
+            section="",
+            breadcrumb_label="Ekonomi",
+        )
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        item = s.queue_.get_nowait()
+        assert item["category"] == "Ekonomi"
+
+    @pytest.mark.asyncio
+    async def test_content_cleanup_strips_non_article_blocks(self):
+        """Noise blocks (``<script>``, ``<aside class="baca-juga-box">``,
+        ``<aside class="sidebar">``) MUST be stripped from content."""
+        html = _ntv_article_html(
+            extra_blocks=(
+                '<script>alert("ad")</script>'
+                '<aside class="baca-juga-box"><p>baca-juga cross-promo must be stripped.</p></aside>'
+                '<aside class="sidebar"><p>Sidebar promo must be stripped.</p></aside>'
+            ),
+        )
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        item = s.queue_.get_nowait()
+        assert "NTV lead paragraph" in item["content"]
+        assert "baca-juga" not in item["content"].lower()
+        assert "sidebar promo" not in item["content"].lower()
+        assert "alert(" not in item["content"]
+
+    @pytest.mark.asyncio
+    async def test_missing_title_drops_article(self):
+        html = _ntv_article_html().replace('<h1 class="title">NTV test headline</h1>', "")
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        assert s.queue_.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_publish_date_drops_article(self):
+        """Drop JSON-LD entirely → no publish_date → drop the article."""
+        html = _ntv_article_html()
+        # Remove the JSON-LD script tag entirely.
+        import re as _re
+        html = _re.sub(
+            r'<script type="application/ld\+json">.*?</script>',
+            "",
+            html,
+            count=1,
+            flags=_re.DOTALL,
+        )
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        assert s.queue_.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_content_drops_article(self):
+        html = _ntv_article_html()
+        # Remove the .article-content container.
+        html = html.replace(
+            '<div class="article-content">',
+            '<div class="NOOP">',
+        )
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        _attach_fetch(s, {self.LINK: html})
+        await s.get_article(self.LINK, self.KEYWORD)
+        assert s.queue_.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_future_start_date_drops_and_flips_continue_scraping(self):
+        s = NTVNewsScraper(
+            keywords=self.KEYWORD,
+            start_date=datetime(2099, 1, 1),
+            queue_=asyncio.Queue(),
+        )
+        _attach_fetch(s, {self.LINK: _ntv_article_html()})
+        await s.get_article(self.LINK, self.KEYWORD)
+        assert s.queue_.qsize() == 0
+        assert s.continue_scraping is False
+
+    @pytest.mark.asyncio
+    async def test_get_article_rejects_non_canonical_link(self):
+        off_pattern = "https://www.ntvnews.id/tag/12345678/abc/"
+        s = NTVNewsScraper(keywords=self.KEYWORD, queue_=asyncio.Queue())
+        stub = _attach_fetch(s, {off_pattern: _ntv_article_html()})
+        await s.get_article(off_pattern, self.KEYWORD)
+        # No fetch, no queue write — guards against article fetches for
+        # taxonomy/non-canonical URLs that the parser already filters.
+        assert stub.calls == []
+        assert s.queue_.qsize() == 0

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -60,13 +60,17 @@ from typing import Any
 from urllib.parse import quote
 
 import pytest
+from bs4 import BeautifulSoup
 
 from newswatch.scrapers.alinea import AlineaScraper
 from newswatch.scrapers.betahita import BetahitaScraper
 from newswatch.scrapers.conversationid import ConversationIDScraper
 from newswatch.scrapers.ddtcnews import DDTCNewsScraper
 from newswatch.scrapers.gnfi import GNFIScraper
+from newswatch.scrapers.dailysocial import DailySocialScraper
+from newswatch.scrapers.katadata import KatadataScraper
 from newswatch.scrapers.hukumonline import HukumonlineScraper
+from newswatch.scrapers.kaltimpost import KaltimPostScraper
 from newswatch.scrapers.idnfinancials import IDNFinancialsScraper
 from newswatch.scrapers.independen import IndependenScraper
 from newswatch.scrapers.kumparan import KumparanScraper
@@ -77,6 +81,7 @@ from newswatch.scrapers.wartaekonomi import WartaEkonomiScraper
 from newswatch.scrapers.idxchannel import IDXChannelScraper
 from newswatch.scrapers.infobanknews import InfobanknewsScraper
 from newswatch.scrapers.indopolitika import IndopolitikaScraper
+from newswatch.scrapers.voi import VOIScraper
 
 
 # ── Shared offline test scaffolding ────────────────────────────────────────
@@ -162,6 +167,134 @@ class TestKumparanXMLParser:
         assert await scraper.build_latest_url(1) == self.RSS_XML
         assert await scraper.build_latest_url(2) is None
         assert calls == [(scraper.rss_url, {"headers": scraper.headers, "timeout": 30})]
+
+def _kumparan_article_html(payload: Any, meta_date: str | None = None) -> str:
+    meta = (
+        f'<meta property="article:published_time" content="{meta_date}">'
+        if meta_date
+        else ""
+    )
+    return (
+        '<!doctype html><html><head>'
+        '<meta property="og:title" content="Kumparan fixture headline">'
+        '<meta name="author" content="Kumparan Fixture Reporter">'
+        f'{meta}<script type="application/ld+json">{json.dumps(payload)}</script>'
+        '</head><body><div class="article-content">'
+        '<p>Fixture lead paragraph long enough for Kumparan content filtering.</p>'
+        '<p>Fixture follow-up paragraph also stays inside the article content.</p>'
+        '</div></body></html>'
+    )
+
+
+class TestKumparanArticleDateFallback:
+    LINK = "https://kumparan.com/kumparannews/fixture-article"
+    JSONLD_DATE = "2026-07-21T08:15:30+07:00"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        (
+            pytest.param(
+                {"@type": "NewsArticle", "datePublished": JSONLD_DATE},
+                id="object",
+            ),
+            pytest.param(
+                [
+                    {"@type": "WebSite"},
+                    {"@type": "NewsArticle", "datePublished": JSONLD_DATE},
+                ],
+                id="list",
+            ),
+            pytest.param(
+                {
+                    "@graph": [
+                        {"@type": "WebPage"},
+                        {"@type": "NewsArticle", "datePublished": JSONLD_DATE},
+                    ]
+                },
+                id="graph",
+            ),
+        ),
+    )
+    async def test_newsarticle_jsonld_supplies_missing_meta_date(self, payload):
+        scraper = KumparanScraper("ekonomi", queue_=asyncio.Queue())
+        _attach_fetch(scraper, {self.LINK: _kumparan_article_html(payload)})
+
+        await scraper.get_article(self.LINK, "ekonomi")
+
+        item = scraper.queue_.get_nowait()
+        assert tuple(item) == _QUEUE_KEYS
+        assert item["publish_date"] == datetime(2026, 7, 21, 8, 15, 30)
+
+    @pytest.mark.asyncio
+    async def test_valid_meta_date_keeps_precedence_over_jsonld(self):
+        payload = {
+            "@type": "NewsArticle",
+            "datePublished": "2025-01-02T03:04:05+07:00",
+        }
+        html = _kumparan_article_html(
+            payload,
+            meta_date="2026-07-20T09:10:11+07:00",
+        )
+        scraper = KumparanScraper("ekonomi", queue_=asyncio.Queue())
+        _attach_fetch(scraper, {self.LINK: html})
+
+        await scraper.get_article(self.LINK, "ekonomi")
+
+        item = scraper.queue_.get_nowait()
+        assert item["publish_date"] == datetime(2026, 7, 20, 9, 10, 11)
+
+
+def _dailysocial_cards_html() -> str:
+    return """<!doctype html><html><body>
+        <header><a href="/post/header-leak">Header link</a></header>
+        <article class="type-post">
+            <a href="/post/image-link-leak">Image link outside title</a>
+            <h2 class="entry-title"><a href="/post/relative-fixture">Relative fixture</a></h2>
+        </article>
+        <article class="type-post featured">
+            <h2 class="entry-title">
+                <a href="https://news.dailysocial.id/post/absolute-fixture">Absolute fixture</a>
+            </h2>
+        </article>
+        <article class="type-post">
+            <h2 class="entry-title"><a href="/category/startup">Category</a></h2>
+        </article>
+        <article class="type-post">
+            <h2 class="entry-title">
+                <a href="https://other.example.com/post/offsite">Off-site article</a>
+            </h2>
+        </article>
+        <div class="wp-block-post"><a href="/post/legacy-card">Legacy card</a></div>
+    </body></html>"""
+
+
+class TestDailySocialPrimaryCards:
+    @pytest.mark.parametrize(
+        "parser_name",
+        ("parse_article_links", "parse_latest_article_links"),
+        ids=("search", "latest"),
+    )
+    def test_scopes_primary_entry_title_links_and_preserves_url_validation(
+        self, parser_name,
+    ):
+        scraper = DailySocialScraper("startup", queue_=asyncio.Queue())
+        links = getattr(scraper, parser_name)(_dailysocial_cards_html())
+
+        assert links == {
+            "https://news.dailysocial.id/post/relative-fixture",
+            "https://news.dailysocial.id/post/absolute-fixture",
+        }
+
+    @pytest.mark.parametrize(
+        "parser_name",
+        ("parse_article_links", "parse_latest_article_links"),
+        ids=("search", "latest"),
+    )
+    def test_empty_listing_returns_none(self, parser_name):
+        scraper = DailySocialScraper("startup", queue_=asyncio.Queue())
+        assert getattr(scraper, parser_name)("") is None
+
 
 
 # ── 2. SINDO: latest parser consumes RSS XML from /feed ──────────────────
@@ -1626,10 +1759,11 @@ class TestNewAdapterQueueSchema:
                 '<span class="article-category" itemprop="articleSection">Denpasar</span>'
                 '</div>'
                 '<span itemprop="author">Penulis : I Putu Reporter</span>'
-                '<div class="entry-content" itemprop="articleBody">'
+                '<div class="entry-box" itemprop="articleBody">'
+                '<div class="entry-content">'
                 '<p>NusaBali lead paragraph pulled into the body by the entry-content extractor.</p>'
                 '<p>NusaBali second paragraph retained because it sits inside articleBody.</p>'
-                '</div>'
+                '</div></div>'
                 '</body></html>'
             )
         elif cls is ConversationIDScraper:
@@ -1812,7 +1946,7 @@ class TestNewAdapterStartDateCutoff:
                 '</head><body>'
                 '<span class="month pull-left" itemprop="datePublished">12 Jul 2026 19:37:24</span>'
                 '<span itemprop="author">Penulis : Author</span>'
-                '<div class="entry-content" itemprop="articleBody"><p>x</p></div>'
+                '<div class="entry-box" itemprop="articleBody"><div class="entry-content"><p>x</p></div></div>'
                 '</body></html>'
             )
         elif cls is ConversationIDScraper:
@@ -2467,9 +2601,13 @@ def _nusabali_article_html() -> str:
         <div class="breadcrumb">
             <span class="article-category" itemprop="articleSection">Denpasar</span>
         </div>
-        <div class="entry-content" itemprop="articleBody">
-            <p>NusaBali lead paragraph retained by the entry-content extractor.</p>
-            <p>NusaBali second paragraph retained because it sits inside articleBody.</p>
+        <div class="entry-box" itemprop="articleBody">
+            <p>Outer summary paragraph must not leak into collected content.</p>
+            <div class="entry-content">
+                <p>NusaBali lead paragraph retained by the entry-content extractor.</p>
+                <p>NusaBali second paragraph retained because it sits inside articleBody.</p>
+            </div>
+            <p>Outer recommendation paragraph must not leak into collected content.</p>
         </div>
     </body></html>"""
 
@@ -2552,6 +2690,20 @@ class TestNusaBaliFocus:
         assert item["category"] == "Denpasar"
         assert item["source"] == "nusabali.com"
         assert item["link"] == link
+        assert "NusaBali lead paragraph" in item["content"]
+        assert "NusaBali second paragraph" in item["content"]
+        assert "Outer summary" not in item["content"]
+        assert "Outer recommendation" not in item["content"]
+
+    def test_content_falls_back_to_article_body_root_without_inner_content(self):
+        html = """<!doctype html><html><body>
+            <div class="entry-box" itemprop="articleBody">
+                <p>NusaBali root paragraph retained when entry-content is absent.</p>
+            </div>
+        </body></html>"""
+        assert self._scraper()._extract_content(BeautifulSoup(html, "html.parser")) == (
+            "NusaBali root paragraph retained when entry-content is absent."
+        )
 
     @pytest.mark.asyncio
     async def test_category_falls_back_to_unknown_when_no_breadcrumb(self):
@@ -2561,8 +2713,10 @@ class TestNusaBaliFocus:
         </head><body>
             <span class="month pull-left" itemprop="datePublished">12 Jul 2026 19:37:24</span>
             <span itemprop="author">Some Author</span>
-            <div class="entry-content" itemprop="articleBody">
-                <p>NusaBali body paragraph for the unknown-category fallback test path.</p>
+            <div class="entry-box" itemprop="articleBody">
+                <div class="entry-content">
+                    <p>NusaBali body paragraph for the unknown-category fallback test path.</p>
+                </div>
             </div>
         </body></html>"""
         s = NusaBaliScraper(keywords="bali", queue_=asyncio.Queue())
@@ -2704,12 +2858,47 @@ class TestConversationIDFocus:
         assert item["publish_date"] == datetime(2026, 7, 12, 12, 0, 0)
         assert item["publish_date"].tzinfo is None
 
+class TestKaltimPostFocus:
+    @pytest.mark.asyncio
+    async def test_search_uses_current_endpoint_and_stops_after_page_one(self):
+        scraper = KaltimPostScraper(keywords="nasional", queue_=asyncio.Queue())
+        stub = _attach_fetch(scraper, {"": "<html></html>"})
 
-def _hukumonline_sitemap_xml(urls: list[str]) -> str:
+        await scraper.build_search_url("nasional", 1)
+
+        assert stub.calls[0][0] == "https://borneo24.com/search?q=nasional"
+        assert await scraper.build_search_url("nasional", 2) is None
+
+    def test_search_scopes_primary_cards_while_latest_accepts_pagewide_roots(self):
+        scraper = KaltimPostScraper(keywords="nasional", queue_=asyncio.Queue())
+        html = """<html><body>
+            <div class="post-item"><h3 class="title">
+                <a href="/primary-story">Primary</a>
+                <a href="/category/news">Nested</a>
+                <a href="https://example.com/offsite">Offsite</a>
+            </h3></div>
+            <aside><a href="/sidebar-story">Sidebar</a></aside>
+            <a href="/query-story?ref=home">Query</a>
+            <a href="/category/">Category</a>
+        </body></html>"""
+
+        assert scraper.parse_article_links(html) == {
+            "https://borneo24.com/primary-story"
+        }
+        assert scraper.parse_latest_article_links(html) == {
+            "https://borneo24.com/primary-story",
+            "https://borneo24.com/sidebar-story",
+        }
+
+
+
+def _hukumonline_sitemap_xml(urls: list[str | tuple[str, str]]) -> str:
     body = '<?xml version="1.0" encoding="UTF-8"?>\n'
     body += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-    for u in urls:
-        body += f"  <url><loc>{u}</loc></url>\n"
+    for record in urls:
+        url, lastmod = record if isinstance(record, tuple) else (record, "")
+        lastmod_xml = f"<lastmod>{lastmod}</lastmod>" if lastmod else ""
+        body += f"  <url><loc>{url}</loc>{lastmod_xml}</url>\n"
     body += "</urlset>\n"
     return body
 
@@ -2761,6 +2950,41 @@ class TestHukumonlineFocus:
             "https://www.hukumonline.com/berita/a/canonical-slug",
             "https://www.hukumonline.com/berita/a/multi-segment/slug",
             "https://www.hukumonline.com/berita/a/canonical-slug-with-trailing",
+        ]
+    def test_latest_parser_excludes_photo_aliases_and_selects_newest_ten(self):
+        scraper = HukumonlineScraper(keywords="hukum", queue_=asyncio.Queue())
+        base = "https://www.hukumonline.com/berita"
+        records = [
+            (f"{base}/foto/f/photo-alias", "2026-07-22"),
+            (f"{base}/a/photo-alias", "2026-07-22"),
+            (f"{base}/a/old-section", "2026-05-01"),
+            (f"{base}/a/story-03", "2026-07-20"),
+            (f"{base}/a/story-01", "2026-07-22"),
+            (f"{base}/a/story-02", "2026-07-22"),
+            (f"{base}/a/story-04", "2026-07-19"),
+            (f"{base}/a/story-05", "2026-07-18"),
+            (f"{base}/a/story-06", "2026-07-17"),
+            (f"{base}/a/story-07", "2026-07-16"),
+            (f"{base}/a/story-08", "2026-07-15"),
+            (f"{base}/a/story-09", "2026-07-14"),
+            (f"{base}/a/story-10", "2026-07-13"),
+            (f"{base}/a/story-11", "2026-07-12"),
+            (f"{base}/a/story-01", "2026-07-22"),
+        ]
+
+        links = scraper.parse_latest_article_links(_hukumonline_sitemap_xml(records))
+
+        assert links == [
+            f"{base}/a/story-01",
+            f"{base}/a/story-02",
+            f"{base}/a/story-03",
+            f"{base}/a/story-04",
+            f"{base}/a/story-05",
+            f"{base}/a/story-06",
+            f"{base}/a/story-07",
+            f"{base}/a/story-08",
+            f"{base}/a/story-09",
+            f"{base}/a/story-10",
         ]
 
     def test_latest_parser_rejects_html_doc_html(self):
@@ -3188,3 +3412,120 @@ class TestIndopolitikaFocus:
 
         assert s.queue_.qsize() == 0
         assert s.continue_scraping is False
+
+
+# ── 13. Katadata and VOI: current latest-card URL contracts ───────────────
+
+
+def _katadata_latest_html() -> str:
+    return """<!doctype html><html><body>
+<header><a href="/ekonomi/aabbcc11/outside-card">scoped out</a></header>
+<article class="article--berita">
+  <a href="/ekonomi/makro/686FAB01/current-headline?utm_source=index#summary">relative current</a>
+  <a href="https://katadata.co.id/digital/teknologi/a1b2c3d4/deeper-category-story/">absolute current</a>
+  <a href="https://katadata.co.id/digital/teknologi/a1b2c3d4/deeper-category-story/">duplicate</a>
+  <a href="https://katadata.co.id/indeks/a1b2c3d4/not-an-article">index</a>
+  <a href="https://katadata.co.id/tag/a1b2c3d4/not-an-article">taxonomy</a>
+  <a href="https://katadata.co.id/ekonomi/read/old-article-shape">old shape</a>
+  <a href="https://www.katadata.co.id/ekonomi/aabbcc11/wrong-host">www host</a>
+  <a href="https://example.test/ekonomi/aabbcc11/offsite">offsite</a>
+</article>
+<article><a href="/ekonomi/aabbcc11/wrong-card-class">wrong card</a></article>
+</body></html>"""
+
+
+class TestKatadataLatestDiscovery:
+    BASE = "https://katadata.co.id"
+
+    @pytest.mark.asyncio
+    async def test_page_one_fetches_absolute_index_and_higher_pages_stop(self):
+        scraper = KatadataScraper(keywords="ekonomi")
+        stub = _attach_fetch(scraper, {f"{self.BASE}/indeks": _katadata_latest_html()})
+
+        assert await scraper.build_latest_url(1) == _katadata_latest_html()
+        assert stub.calls == [(f"{self.BASE}/indeks", None, None)]
+
+        assert await scraper.build_latest_url(2) is None
+        assert stub.calls == [(f"{self.BASE}/indeks", None, None)]
+
+    def test_scoped_cards_canonicalize_current_same_host_article_paths(self):
+        scraper = KatadataScraper(keywords="ekonomi")
+
+        assert scraper.parse_latest_article_links(_katadata_latest_html()) == {
+            f"{self.BASE}/ekonomi/makro/686FAB01/current-headline",
+            f"{self.BASE}/digital/teknologi/a1b2c3d4/deeper-category-story",
+        }
+        assert scraper.parse_latest_article_links("") is None
+
+    @pytest.mark.asyncio
+    async def test_search_api_contract_is_preserved(self):
+        scraper = KatadataScraper(keywords="pasar modal")
+        stub = _attach_fetch(scraper, {scraper.api_url: '{"results": []}'})
+
+        assert await scraper.build_search_url("pasar modal", 3) == '{"results": []}'
+        url, method, request = stub.calls[0]
+        assert url == scraper.api_url
+        assert method == "POST"
+        assert json.loads(request["data"]) == {
+            "q": "pasar modal",
+            "source": "katadata",
+            "sort": "newest",
+            "limit": 10,
+            "page": 3,
+        }
+        assert request["headers"] == {
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0",
+        }
+        assert request["timeout"] == 30
+
+
+def _voi_index_html() -> str:
+    return """<!doctype html><html><body>
+<div class="section-item-title">
+  <a href="/en/economy/123456?utm_source=index#summary">relative current</a>
+</div>
+<div class="section-item-title">
+  <a href="https://voi.id/en/technology/987654/">absolute current</a>
+  <a href="https://voi.id/en/technology/987654/">duplicate</a>
+  <a href="https://voi.id/en/index/22">index</a>
+  <a href="https://voi.id/en/search/33">search</a>
+  <a href="https://voi.id/en/artikel/44">listing namespace</a>
+  <a href="https://voi.id/en/economy/not-numeric">non-numeric id</a>
+  <a href="https://www.voi.id/en/economy/55">www host</a>
+  <a href="https://example.test/en/economy/66">offsite</a>
+</div>
+<a href="/en/economy/777777">right path outside live selector</a>
+</body></html>"""
+
+
+class TestVOIDiscovery:
+    BASE = "https://voi.id"
+
+    @pytest.mark.asyncio
+    async def test_latest_keeps_index_endpoint(self):
+        scraper = VOIScraper(keywords="ekonomi")
+        stub = _attach_fetch(scraper, {"/en/artikel/indeks": _voi_index_html()})
+
+        assert await scraper.build_latest_url(1) == _voi_index_html()
+        assert stub.calls[0][0] == f"{self.BASE}/en/artikel/indeks"
+
+    def test_live_title_selector_keeps_only_current_same_host_article_paths(self):
+        scraper = VOIScraper(keywords="ekonomi")
+        expected = {
+            f"{self.BASE}/en/economy/123456",
+            f"{self.BASE}/en/technology/987654",
+        }
+
+        assert scraper.parse_latest_article_links(_voi_index_html()) == expected
+        assert scraper.parse_article_links(_voi_index_html()) == expected
+        assert scraper.parse_latest_article_links("") is None
+
+    @pytest.mark.asyncio
+    async def test_search_url_contract_and_zero_result_marker_are_preserved(self):
+        scraper = VOIScraper(keywords="pasar modal")
+        stub = _attach_fetch(scraper, {"/en/artikel/cari": _voi_index_html()})
+
+        assert await scraper.build_search_url("pasar modal", 2) == _voi_index_html()
+        assert stub.calls[0][0] == f"{self.BASE}/en/artikel/cari?q=pasar+modal&page=2"
+        assert scraper.parse_article_links("<p>Found 0 articles</p>") is None

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -2085,12 +2085,16 @@ class TestIDXChannelScraper:
 
 def _alinea_search_html(*, url_substring: str = "") -> str:
     return """<!doctype html><html><body>
-        <a href="/politik/foo-bar-b123">in-section</a>
-        <a href="/gaya-hidup/baz-qux-b456">in-section-gaya-hidup</a>
-        <a href="/search?q=foo">search page itself</a>
-        <a href="/lain/foo">unknown section</a>
-        <a href="https://example.com/politik/baz">off-site</a>
-        <a>no href</a>
+        <div class="hasilcari">
+            <div class="box1"><a href="/politik/foo-bar-b123">in-section</a></div>
+            <div class="box1"><a href="/gaya-hidup/baz-qux-b456">in-section-gaya-hidup</a></div>
+            <div class="box1"><a href="/search?q=foo">search page itself</a></div>
+            <div class="box1"><a href="/lain/foo">unknown section</a></div>
+            <div class="box1"><a href="https://example.com/politik/baz">off-site</a></div>
+        </div>
+        <div class="section-popular">
+            <div class="box1"><a href="/politik/sidebar-b999">sidebar</a></div>
+        </div>
     </body></html>"""
 
 


### PR DESCRIPTION
## Summary
- add NTVNews as a stable search/latest source using its bounded Google News sitemap
- enforce independent search/latest page bounds
- refresh confirmed publisher extraction contracts and focused coverage

## Verification
- `uv run pytest tests/test_basescraper.py tests/test_registry.py tests/test_scrapers_focused.py -m "not network" -q` — 187 passed
- `uv run pytest tests/ -m "not network" --timeout=30 -q` — 1187 passed, 21 skipped, 224 deselected
- `uv run ruff check src/newswatch tests` — passed
- `make sources-check` — passed
- NTV live search/latest — 2 passed

## Notes
- preserves the signed stability commits and signed integration merge without rebasing or squashing
- no duplicate DDTC source; Straits Times admission rejected because SPH terms prohibit automated scraping without permission
