### PR TITLE
chore: prepare release 1.2.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - name: "Okky Mabruri"
     website: "okkymabruri.github.io"
     orcid: "https://orcid.org/0000-0002-2103-1311"
-version: 1.2.2
+version: 1.2.3
 abstract: "news-watch: Indonesia's top news websites scraper. A Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 publisher: Zenodo
 doi: "10.5281/zenodo.14908389"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-07-23
+
 ### Added
 - NTVNews.id (`ntvnews`) with bounded Google News sitemap search and latest discovery
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "news-watch"
-version = "1.2.2"
+version = "1.2.3"
 description = "news-watch is a Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/newswatch/__init__.py
+++ b/src/newswatch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 # health report
 from .health import health_report as health_report

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "news-watch"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump package and citation metadata to 1.2.3
- promote the complete Unreleased notes to the dated 1.2.3 section
- preserve an empty Unreleased section for future changes

## Validation
- `make release-validate VERSION=1.2.3` — passed
- `uv lock --check` — passed
- `make sources-check` — passed
- `uv run --extra dev ruff check` — passed
- `uv run --extra dev pytest tests/ -m "not network" --timeout=30 -q` — 1187 passed, 21 skipped, 224 deselected

The release commit is signed by okkymabruri <hello@okky.dev> with fingerprint D58C157FB9F0F4F11F1BF4C6CC0183289A75A7C0.