### PR TITLE
fix: cap scraper concurrency, honor scraper-timeout, stop writer data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ newswatch --method <search|latest> -k <keywords> -sd <start_date> -s [<scrapers>
 | `-k, --keywords` | Comma-separated keywords to scrape (required for `search`, optional for `latest`) |
 | `-sd, --start_date` | Start date in YYYY-MM-DD format (required for `search`, ignored in `latest`) |
 | `-s, --scrapers` | Scrapers to use: specific names (e.g., `"kompas,viva"`), `"auto"` (default, platform-appropriate), or `"all"` (force all, may fail) |
-| `-of, --output_format` | Output format: `csv`, `xlsx`, `json`, or `jsonl` (default: csv) |
+| `-of, --output_format` | Output format: `csv`, `xlsx`, `json`, or `jsonl` (default: csv). `csv` and `jsonl` stream to disk incrementally; `xlsx` and `json` are held in memory and written once at the end |
 | `-o, --output_path` | Custom output file path (optional) |
 | `-v, --verbose` | Show detailed logging output (default: silent) |
 | `--list_scrapers` | List all supported scrapers and exit |
@@ -76,6 +76,7 @@ newswatch --method <search|latest> -k <keywords> -sd <start_date> -s [<scrapers>
 | `--limit` | Maximum number of articles to collect in latest mode |
 | `--max-pages` | Maximum pages to fetch per scraper in latest mode |
 | `--scraper-timeout` | Per-scraper timeout in seconds |
+| `--max-concurrent-scrapers` | Maximum scrapers running at once (default: 6). Browser-required scrapers share a smaller pool capped at 2 |
 | `--progress` | Print per-scraper progress lines |
 | `--daterange` | Filter articles by an inclusive date window. Format: `YYYY-MM-DD/YYYY-MM-DD` (e.g. `2026-07-13/2026-07-14`); start = 00:00:00, end = 23:59:59.999999 of the same day |
 | `--dedup-file` | Path to a previous output file (JSON/JSONL/CSV); articles with matching links are skipped |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,6 +18,7 @@ scrape(
     max_pages=None,
     *,
     scraper_timeout=None,
+    max_concurrent_scrapers=6,
     time_range=None,
     dedup_file=None,
     proxy=None,
@@ -33,6 +34,7 @@ scrape(
 - `limit`: maximum collected articles; mainly useful for latest mode.
 - `max_pages`: latest pages per scraper.
 - `scraper_timeout`: timeout for each scraper.
+- `max_concurrent_scrapers`: maximum scrapers running at once (default 6); browser-required sources share a smaller pool capped at 2.
 - `time_range`: inclusive date-only window, `START/END` as `YYYY-MM-DD/YYYY-MM-DD` (start 00:00:00, end 23:59:59.999999). This is the Python keyword only — CLI users pass the same value via the canonical `--daterange` flag. The previously deprecated `--time-range` CLI alias was removed in 1.2.0; the Python `time_range=` keyword remains supported and is distinct from that removed flag.
 - `dedup_file`: prior CSV, JSON, or JSONL output whose links should be skipped.
 - `proxy`: proxy URL used by HTTP and browser request layers.
@@ -75,6 +77,7 @@ scrape_to_file(
     max_pages=None,
     *,
     scraper_timeout=None,
+    max_concurrent_scrapers=6,
     time_range=None,
     dedup_file=None,
     proxy=None,
@@ -100,19 +103,22 @@ nw.scrape_to_file(
 latest(
     scrapers="auto", verbose=False, timeout=300,
     limit=None, max_pages=None, *, scraper_timeout=None,
+    max_concurrent_scrapers=6,
     time_range=None, dedup_file=None, proxy=None,
 ) -> list[dict]
 
 latest_to_dataframe(
     scrapers="auto", verbose=False, timeout=300,
     limit=None, max_pages=None, *, scraper_timeout=None,
+    max_concurrent_scrapers=6,
     time_range=None, dedup_file=None, proxy=None,
 ) -> pandas.DataFrame
 
 latest_to_file(
     output_path, output_format="xlsx", scrapers="auto",
     verbose=False, timeout=300, limit=None, max_pages=None,
-    *, scraper_timeout=None, time_range=None,
+    *, scraper_timeout=None, max_concurrent_scrapers=6,
+    time_range=None,
     dedup_file=None, proxy=None,
 ) -> None
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,12 +22,12 @@ flowchart TD
 
 | File | Role |
 |---|---|
-| `registry.py` | Single source of truth for status, capabilities, metadata, runtime loading, tests, and generated documentation |
-| `main.py` | Orchestrates scraper selection and execution |
-| `api.py` | Synchronous Python API (`scrape`, `scrape_to_dataframe`, latest and health helpers) |
+| `registry.py` | Single source of truth for status, capabilities, metadata, runtime loading, tests, and generated documentation; declares `browser_required` and `keyword_concurrency` per source |
+| `main.py` | Orchestrates scraper selection, the concurrency cap, and execution |
+| `api.py` | Synchronous Python API (`scrape`, `scrape_to_dataframe`, latest and health helpers) — applies the same concurrency cap as the CLI |
 | `cli.py` | CLI entry point |
 | `scrapers/basescraper.py` | Abstract contract — `build_search_url`, `parse_article_links`, `get_article` |
-| `utils.py` | `AsyncScraper` — concurrency, WAF fallback (aiohttp → rnet → Playwright) |
+| `utils.py` | `AsyncScraper` — request and keyword concurrency, WAF fallback (aiohttp → rnet → Playwright) |
 
 ## Retrieval Methods
 
@@ -56,6 +56,24 @@ A source declares search support only if:
 4. extracted URLs are canonical same-site article pages
 
 Latest support is validated independently; a source can be latest-only.
+
+## Concurrency Model
+
+Two independent limits apply.
+
+**Across scrapers.** The CLI and the Python API each cap how many scraper
+instances run at once (`--max-concurrent-scrapers` / `max_concurrent_scrapers=`,
+default 6). Browser-required sources draw from a separate, smaller pool capped
+at 2, because each Playwright launch costs a Chromium process rather than a
+socket. Selected scrapers therefore run in waves; the CLI's outer batch timeout
+is derived from the wave count rather than a fixed ceiling.
+
+**Within one scraper.** `AsyncScraper` holds two distinct semaphores.
+`semaphore` bounds concurrent HTTP requests inside `fetch()`. `keyword_semaphore`
+bounds concurrent per-keyword tasks in `BaseScraper.scrape()` and is sized from
+the registry's `keyword_concurrency`, which defaults to 1 for browser-required
+sources. Only `fetch()` observes the first, so browser-driven scrapers that
+bypass `fetch()` are bounded by the second.
 
 <!-- BEGIN GENERATED: architecture-state -->
 ## Current State

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -270,7 +270,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new stable scrapers: `bbc`, `beritajatim`, `pikiranrakyat`, `poskota`, `rmid`, `suaramerdeka`, `jpnn`, `surabayapagi`, `galamedia`
 - Moved scraper loading to the central registry-driven runtime
 - Reworked `jpnn`, `surabayapagi`, and `galamedia` for the current strict-search flow
-- Aligned recovered scrapers with `dev/SCRAPER_TEMPLATE.md` patterns
+- Aligned recovered scrapers with the shared scraper template patterns
 
 ## Quality
 - Recovered `pikiranrakyat` via Playwright CSE after Cloudflare 1015 blocks

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--max-concurrent-scrapers` CLI flag and `max_concurrent_scrapers=` Python keyword (default 6) capping how many scrapers run at once; browser-required sources share a separate pool capped at 2
+- `keyword_concurrency` registry field (default 1 for browser-required sources) bounding concurrent per-keyword tasks within one scraper run
+
+### Changed
+- The CLI's outer batch timeout is derived from the concurrency-wave count instead of a fixed 180 seconds, so `--scraper-timeout` is no longer silently overridden
+- `--output_format` help text now states that csv/jsonl stream incrementally while xlsx/json buffer in memory and write once
+
+### Fixed
+- `--scrapers all` no longer launches every registered scraper simultaneously (#47)
+- Browser-required scrapers now honor a real per-keyword concurrency limit; most previously ignored the configured bound entirely
+- Output writers report partial results explicitly on cancellation instead of discarding collected rows
+- The Python API path applies the same concurrency cap as the CLI and warns when the overall `timeout` truncates a run
+
 ## [1.2.3] - 2026-07-23
 
 ### Added

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,6 +104,9 @@ newswatch \
   --progress
 ```
 
+`--max-concurrent-scrapers` bounds how many sources run at once (default 6).
+Lower it on small machines; browser-driven sources are already limited to 2.
+
 Cloud and shared IPs are blocked more often than local connections. See [Troubleshooting](troubleshooting.md) for proxies and source-level diagnosis.
 
 ## Next

--- a/docs/practical-guide.md
+++ b/docs/practical-guide.md
@@ -119,11 +119,12 @@ export NEWSWATCH_MAX_RETRIES=3
 newswatch --keywords ihsg --start_date 2025-01-01
 ```
 
-All knobs also work as keyword arguments (`proxy=`, `scraper_timeout=`) or CLI flags.
+All knobs also work as keyword arguments (`proxy=`, `scraper_timeout=`, `max_concurrent_scrapers=`) or CLI flags.
 
 ## Reliability and limits
 
 - **Local runs are most reliable.** Cloud and shared IPs get blocked more often; route through `--proxy` when running on Colab or CI.
+- **Concurrency is capped.** At most 6 scrapers run at once (`--max-concurrent-scrapers` / `max_concurrent_scrapers=`), with browser-driven sources limited to 2. Large `scrapers="all"` runs therefore proceed in waves — raise `timeout=` accordingly or the run returns partial results.
 - **Strict-search policy** — sources with `Yes` in the Search column of [index.md](index.md) have verified keyword workflows; a non-empty result for a nonsense keyword is a bug, not a feature.
 - **AP News** uses topic hub pages with keyword-in-title filtering (no `/search?q=`); **Al Jazeera** is latest-only via RSS.
 - **Output defaults:** CLI writes CSV in the working directory; `scrape_to_file` defaults to XLSX. Honor both, or pass `output_format` explicitly.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,11 @@ newswatch \
   --progress
 ```
 
+Scrapers run in waves once the concurrency cap (`--max-concurrent-scrapers`,
+default 6) is applied, so total wall time scales with the number of waves
+rather than a single flat limit: roughly (scrapers ÷ cap) × `--scraper-timeout`.
+Lowering the cap reduces peak CPU and memory but lengthens the run.
+
 Cloud, CI, and shared IP addresses are blocked more often. Configure one proxy for all HTTP and browser layers:
 
 ```bash

--- a/docs/use-case-mbg.md
+++ b/docs/use-case-mbg.md
@@ -45,10 +45,14 @@ uv run newswatch \
   --daterange "2025-01-05/2026-07-17" \
   --scrapers all \
   --scraper-timeout 180 \
+  --max-concurrent-scrapers 6 \
   --output_format jsonl \
   --output_path mbg-all.jsonl \
   --progress
 ```
+
+Sources run in waves under the concurrency cap, so wall-clock time is
+roughly (sources ÷ cap) × `--scraper-timeout`, not a single flat timeout.
 
 What `--scrapers all` resolves to in this repo:
 

--- a/src/newswatch/api.py
+++ b/src/newswatch/api.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import os
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Union
@@ -358,12 +359,24 @@ async def _async_scrape_to_list(
         )
 
         if not done:
+            pending_count = sum(1 for t in scraper_tasks if not t.done())
             all_scrapers_done.cancel()
             for t in scraper_tasks:
                 if not t.done():
                     t.cancel()
             logging.warning(
                 f"Scraping took too long and was stopped after {timeout} seconds. {total_scrapers} scrapers were running."
+            )
+            # logging is disabled by default (verbose=False), which would
+            # make the line above silent -- warnings.warn is unaffected by
+            # logging.disable, so truncation stays visible either way.
+            warnings.warn(
+                f"newswatch: scraping stopped after the {timeout}s overall "
+                f"budget; results are partial ({pending_count}/{total_scrapers} "
+                f"scrapers still running). With max_concurrent_scrapers="
+                f"{max_concurrent_scrapers}, scrapers run in waves -- raise "
+                f"timeout= for large runs.",
+                stacklevel=2,
             )
         elif limit_hit in done:
             # Limit reached — cancel remaining scraper work
@@ -383,8 +396,17 @@ async def _async_scrape_to_list(
             # Scrapers finished — clean up limit watcher
             limit_hit.cancel()
     except asyncio.TimeoutError:
+        pending_count = sum(1 for t in scraper_tasks if not t.done())
         logging.warning(
             f"Scraping took too long and was stopped after {timeout} seconds. {total_scrapers} scrapers were running."
+        )
+        warnings.warn(
+            f"newswatch: scraping stopped after the {timeout}s overall "
+            f"budget; results are partial ({pending_count}/{total_scrapers} "
+            f"scrapers still running). With max_concurrent_scrapers="
+            f"{max_concurrent_scrapers}, scrapers run in waves -- raise "
+            f"timeout= for large runs.",
+            stacklevel=2,
         )
         for t in scraper_tasks:
             if not t.done():

--- a/src/newswatch/api.py
+++ b/src/newswatch/api.py
@@ -21,6 +21,7 @@ import pandas as pd
 from .exceptions import NewsWatchError, ValidationError
 from .main import get_available_scrapers
 from .main import _load_dedup_links, _parse_time_range
+from .registry import get_scraper_by_slug
 
 
 class MockArgs:
@@ -165,6 +166,7 @@ async def _async_scrape_to_list(
     max_pages: int | None = None,
     *,
     scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None,
     dedup_file: str | None = None,
 ) -> List[Dict]:
@@ -239,8 +241,10 @@ async def _async_scrape_to_list(
     else:
         scrapers_to_run = [name.strip().lower() for name in scrapers.split(",")]
 
-    # instantiate scrapers
-    scraper_instances = []
+    # instantiate scrapers, keeping (slug, instance) pairs together so
+    # semaphore selection below never has to guess which slug an instance
+    # came from
+    scraper_entries = []
     for scraper_name in scrapers_to_run:
         scraper_info = scraper_classes.get(scraper_name)
         if scraper_info:
@@ -263,9 +267,11 @@ async def _async_scrape_to_list(
             if parsed_tr is not None:
                 scraper_instance.start_datetime = parsed_tr[0]
                 scraper_instance.end_datetime = parsed_tr[1]
-            scraper_instances.append(scraper_instance)
+            scraper_entries.append((scraper_name, scraper_instance))
         else:
             logging.warning(f"scraper '{scraper_name}' is not recognized.")
+
+    scraper_instances = [instance for _, instance in scraper_entries]
 
     if not scraper_instances:
         logging.error("no valid scrapers selected.")
@@ -294,26 +300,43 @@ async def _async_scrape_to_list(
     # run all scrapers concurrently with per-scraper timeout isolation
     scraper_stats: Dict[str, Dict] = {}
 
-    async def _run_with_timeout(scraper, timeout_val):
+    # Global cap on how many scrapers run at once (issue #47), mirroring
+    # main.py's CLI dispatch: with no cap, scrapers="all" fires every
+    # registry entry as a concurrent task, and the browser-required ones
+    # each launch their own Chromium process on top of that. Browser
+    # scrapers share a separate, smaller pool for the same reason.
+    general_sem = asyncio.Semaphore(max_concurrent_scrapers)
+    browser_sem = asyncio.Semaphore(min(2, max_concurrent_scrapers))
+
+    async def _run_with_timeout(scraper, timeout_val, sem):
         scraper_name = type(scraper).__name__
-        try:
-            if timeout_val:
-                await asyncio.wait_for(scraper.scrape(method=method), timeout=timeout_val)
-            else:
-                await scraper.scrape(method=method)
-            scraper_stats[scraper_name] = {"status": "ok"}
-        except asyncio.TimeoutError:
-            logging.warning(
-                f"Scraper {scraper_name} timed out after {timeout_val}s"
-            )
-            scraper_stats[scraper_name] = {"status": "timeout"}
-        except Exception as e:
-            logging.error(f"Scraper {scraper_name} failed: {e}")
-            scraper_stats[scraper_name] = {"status": "error"}
+        async with sem:
+            try:
+                if timeout_val:
+                    await asyncio.wait_for(scraper.scrape(method=method), timeout=timeout_val)
+                else:
+                    await scraper.scrape(method=method)
+                scraper_stats[scraper_name] = {"status": "ok"}
+            except asyncio.TimeoutError:
+                logging.warning(
+                    f"Scraper {scraper_name} timed out after {timeout_val}s"
+                )
+                scraper_stats[scraper_name] = {"status": "timeout"}
+            except Exception as e:
+                logging.error(f"Scraper {scraper_name} failed: {e}")
+                scraper_stats[scraper_name] = {"status": "error"}
 
     scraper_tasks = [
-        asyncio.create_task(_run_with_timeout(scraper, scraper_timeout))
-        for scraper in scraper_instances
+        asyncio.create_task(
+            _run_with_timeout(
+                scraper,
+                scraper_timeout,
+                browser_sem
+                if getattr(get_scraper_by_slug(slug), "browser_required", False)
+                else general_sem,
+            )
+        )
+        for slug, scraper in scraper_entries
     ]
 
     # start collector task (runs concurrently with scrapers)
@@ -408,6 +431,7 @@ def scrape(
     max_pages: int | None = None,
     *,
     scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None,
     dedup_file: str | None = None,
     proxy: str | None = None,
@@ -425,6 +449,8 @@ def scrape(
         method (str): Retrieval method - "search" or "latest"
         limit (int | None): Maximum number of articles to collect (latest mode)
         max_pages (int | None): Maximum pages to fetch per scraper
+        scraper_timeout (int | None): Per-scraper timeout in seconds
+        max_concurrent_scrapers (int): Maximum scrapers running at once (default 6). Browser-required scrapers share a smaller pool capped at 2.
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.
         proxy (str | None): Proxy URL for all requests (e.g. 'http://user:pass@proxy.example.com:8080', 'socks5://proxy.example.com:1080'). Sets NEWSWATCH_PROXY.
@@ -454,6 +480,7 @@ def scrape(
             _async_scrape_to_list(
                 keywords, start_date, scrapers, verbose, timeout, method, limit, max_pages,
                 scraper_timeout=scraper_timeout,
+                max_concurrent_scrapers=max_concurrent_scrapers,
                 time_range=time_range, dedup_file=dedup_file,
             )
         )
@@ -486,6 +513,7 @@ def scrape_to_dataframe(
     max_pages: int | None = None,
     *,
     scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None,
     dedup_file: str | None = None,
     proxy: str | None = None,
@@ -504,6 +532,7 @@ def scrape_to_dataframe(
         limit (int | None): Maximum number of articles to collect (latest mode)
         max_pages (int | None): Maximum pages to fetch per scraper
         scraper_timeout (int | None): Per-scraper timeout in seconds
+        max_concurrent_scrapers (int): Maximum scrapers running at once (default 6). Browser-required scrapers share a smaller pool capped at 2.
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.
         proxy (str | None): Proxy URL for all requests. Sets NEWSWATCH_PROXY.
@@ -519,7 +548,8 @@ def scrape_to_dataframe(
     try:
         results = scrape(
             keywords, start_date, scrapers, verbose, timeout, method, limit, max_pages,
-            scraper_timeout=scraper_timeout, time_range=time_range, dedup_file=dedup_file, proxy=proxy, **kwargs
+            scraper_timeout=scraper_timeout, max_concurrent_scrapers=max_concurrent_scrapers,
+            time_range=time_range, dedup_file=dedup_file, proxy=proxy, **kwargs
         )
 
         # define column order
@@ -565,6 +595,7 @@ def scrape_to_file(
     max_pages: int | None = None,
     *,
     scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None,
     dedup_file: str | None = None,
     proxy: str | None = None,
@@ -585,6 +616,7 @@ def scrape_to_file(
         limit (int | None): Maximum number of articles to collect (latest mode)
         max_pages (int | None): Maximum pages to fetch per scraper
         scraper_timeout (int | None): Per-scraper timeout in seconds
+        max_concurrent_scrapers (int): Maximum scrapers running at once (default 6). Browser-required scrapers share a smaller pool capped at 2.
         time_range (str | None): Filter articles by date window. Format: YYYY-MM-DD/YYYY-MM-DD, inclusive of both full calendar days (start 00:00:00, end 23:59:59.999999).
         dedup_file (str | None): Path to previous output file for deduplication.
         proxy (str | None): Proxy URL for all requests. Sets NEWSWATCH_PROXY.
@@ -613,7 +645,8 @@ def scrape_to_file(
         # get results as dataframe
         df = scrape_to_dataframe(
             keywords, start_date, scrapers, verbose, timeout, method, limit, max_pages,
-            scraper_timeout=scraper_timeout, time_range=time_range, dedup_file=dedup_file, proxy=proxy, **kwargs
+            scraper_timeout=scraper_timeout, max_concurrent_scrapers=max_concurrent_scrapers,
+            time_range=time_range, dedup_file=dedup_file, proxy=proxy, **kwargs
         )
 
         if df.empty:
@@ -685,6 +718,7 @@ def latest(
     scrapers: str = "auto", verbose: bool = False, timeout: int = 300,
     limit: int | None = None, max_pages: int | None = None,
     *, scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None, dedup_file: str | None = None,
     proxy: str | None = None,
 ) -> List[Dict]:
@@ -699,6 +733,7 @@ def latest(
         limit=limit,
         max_pages=max_pages,
         scraper_timeout=scraper_timeout,
+        max_concurrent_scrapers=max_concurrent_scrapers,
         time_range=time_range,
         dedup_file=dedup_file,
         proxy=proxy,
@@ -709,6 +744,7 @@ def latest_to_dataframe(
     scrapers: str = "auto", verbose: bool = False, timeout: int = 300,
     limit: int | None = None, max_pages: int | None = None,
     *, scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None, dedup_file: str | None = None,
     proxy: str | None = None,
 ) -> pd.DataFrame:
@@ -723,6 +759,7 @@ def latest_to_dataframe(
         limit=limit,
         max_pages=max_pages,
         scraper_timeout=scraper_timeout,
+        max_concurrent_scrapers=max_concurrent_scrapers,
         time_range=time_range,
         dedup_file=dedup_file,
         proxy=proxy,
@@ -739,6 +776,7 @@ def latest_to_file(
     max_pages: int | None = None,
     *,
     scraper_timeout: int | None = None,
+    max_concurrent_scrapers: int = 6,
     time_range: str | None = None,
     dedup_file: str | None = None,
     proxy: str | None = None,
@@ -756,6 +794,7 @@ def latest_to_file(
         limit=limit,
         max_pages=max_pages,
         scraper_timeout=scraper_timeout,
+        max_concurrent_scrapers=max_concurrent_scrapers,
         time_range=time_range,
         dedup_file=dedup_file,
         proxy=proxy,

--- a/src/newswatch/cli.py
+++ b/src/newswatch/cli.py
@@ -93,6 +93,14 @@ def cli():
         help="Per-scraper timeout in seconds. Scrapers exceeding this are cancelled.",
     )
     parser.add_argument(
+        "--max-concurrent-scrapers",
+        type=int,
+        default=6,
+        help="Max scrapers running at once (default: 6). Browser-required scrapers "
+        "(Playwright) share a smaller pool, capped at 2, since each launches its own "
+        "Chromium process.",
+    )
+    parser.add_argument(
         "--progress",
         action="store_true",
         help="Print per-scraper progress lines (implies some verbosity).",

--- a/src/newswatch/cli.py
+++ b/src/newswatch/cli.py
@@ -55,7 +55,9 @@ def cli():
         choices=["csv", "xlsx", "json", "jsonl"],
         default="csv",
         type=str,
-        help="Output file format. Options are csv, xlsx, json, or jsonl. Default is csv.",
+        help="Output file format. Options are csv, xlsx, json, or jsonl. Default is csv. "
+        "csv and jsonl stream to disk incrementally (crash-safer on large runs); "
+        "xlsx and json hold all results in memory and write once at the end.",
     )
     parser.add_argument(
         "--output_path",

--- a/src/newswatch/main.py
+++ b/src/newswatch/main.py
@@ -181,6 +181,23 @@ async def write_csv(queue, output_label, filename=None, limit=None, limit_reache
 
         tmp_filename.replace(filename)
         print(f"Data written to {filename}")
+    except asyncio.CancelledError:
+        # main() cancels the writer if the post-scraping drain runs long
+        # (main.py's `wait_for(writer_task, ...)`). Rows already flushed to
+        # `tmp_filename` must not be stranded there silently -- promote what
+        # exists and say so loudly, rather than leaving a valid-looking run
+        # with no output file at all.
+        if items_written:
+            tmp_filename.replace(filename)
+            logging.warning(
+                f"Writer cancelled: partial output ({items_written} items) "
+                f"written to {filename}"
+            )
+        else:
+            logging.warning(
+                "Writer cancelled before any items were written; no output file created"
+            )
+        raise
     except Exception as e:
         logging.error(f"Error writing to CSV: {e}")
 
@@ -245,6 +262,24 @@ async def write_json(queue, output_label, filename=None, limit=None, limit_reach
             json.dump(articles, jsonfile, indent=2, ensure_ascii=False)
 
         print(f"Data written to {filename}")
+    except asyncio.CancelledError:
+        # `articles` only exists in memory until the final json.dump above;
+        # unlike CSV/JSONL there is no incremental on-disk copy, so a bare
+        # cancellation here would lose every item collected this run, not
+        # just the pending tail. Write what has accumulated before
+        # re-raising, and say so loudly.
+        if articles:
+            with open(filename, mode="w", encoding="utf-8") as jsonfile:
+                json.dump(articles, jsonfile, indent=2, ensure_ascii=False)
+            logging.warning(
+                f"Writer cancelled: partial output ({len(articles)} items) "
+                f"written to {filename}"
+            )
+        else:
+            logging.warning(
+                "Writer cancelled before any items were written; no output file created"
+            )
+        raise
     except Exception as e:
         logging.error(f"Error writing to JSON: {e}")
 
@@ -277,58 +312,76 @@ async def write_xlsx(queue, output_label, filename=None, limit=None, limit_reach
     if time_range:
         time_start, time_end = time_range
 
-    while True:
-        try:
-            # Add a timeout to avoid hanging indefinitely
-            item = await asyncio.wait_for(queue.get(), timeout=30)
-        except asyncio.TimeoutError:
-            # If no items received for 30 seconds, break the loop
-            logging.warning("No items received for 30 seconds, stopping writer")
-            break
-        except RuntimeError as e:
-            if "Event loop is closed" in str(e):
-                break
-            else:
-                raise
-
-        if item is None:  # Sentinel value to stop
-            break
-
-        # Skip duplicates
-        if dedup_links is not None and item.get("link", "") in dedup_links:
-            continue
-
-        # Apply time range filter
-        if time_start is not None or time_end is not None:
-            pub_date = item.get("publish_date")
-            if pub_date:
-                if isinstance(pub_date, str):
-                    try:
-                        pub_date = datetime.fromisoformat(pub_date)
-                    except ValueError:
-                        continue
-                if not isinstance(pub_date, datetime):
-                    continue
-                if time_start is not None and pub_date < time_start:
-                    continue
-                if time_end is not None and pub_date > time_end:
-                    continue
-
-        # Format datetime objects as strings
-        if isinstance(item.get("publish_date"), datetime):
-            item["publish_date"] = item["publish_date"].strftime("%Y-%m-%d %H:%M:%S")
-        items.append(item)
-        items_written += 1
-
-        if limit is not None and items_written >= limit:
-            if limit_reached_event:
-                limit_reached_event.set()
-            break
-
     try:
+        while True:
+            try:
+                # No idle timeout here: a global scraper cap runs scrapers in
+                # waves (see main()), so gaps between items well past 30s
+                # are expected, not a hang. The writer ends via the sentinel
+                # `None` main() puts on the queue after all scrapers finish
+                # (or the outer batch timeout cancels them).
+                item = await queue.get()
+            except RuntimeError as e:
+                if "Event loop is closed" in str(e):
+                    break
+                else:
+                    raise
+
+            if item is None:  # Sentinel value to stop
+                break
+
+            # Skip duplicates
+            if dedup_links is not None and item.get("link", "") in dedup_links:
+                continue
+
+            # Apply time range filter
+            if time_start is not None or time_end is not None:
+                pub_date = item.get("publish_date")
+                if pub_date:
+                    if isinstance(pub_date, str):
+                        try:
+                            pub_date = datetime.fromisoformat(pub_date)
+                        except ValueError:
+                            continue
+                    if not isinstance(pub_date, datetime):
+                        continue
+                    if time_start is not None and pub_date < time_start:
+                        continue
+                    if time_end is not None and pub_date > time_end:
+                        continue
+
+            # Format datetime objects as strings
+            if isinstance(item.get("publish_date"), datetime):
+                item["publish_date"] = item["publish_date"].strftime("%Y-%m-%d %H:%M:%S")
+            items.append(item)
+            items_written += 1
+
+            if limit is not None and items_written >= limit:
+                if limit_reached_event:
+                    limit_reached_event.set()
+                break
+
         df = pd.DataFrame(items, columns=fieldnames)
         df.to_excel(filename, index=False)
         print(f"Data written to {filename}")
+    except asyncio.CancelledError:
+        # `items` only exists in memory until the final to_excel() above;
+        # unlike CSV/JSONL there is no incremental on-disk copy, so a bare
+        # cancellation here would lose every item collected this run, not
+        # just the pending tail. Write what has accumulated before
+        # re-raising, and say so loudly.
+        if items:
+            df = pd.DataFrame(items, columns=fieldnames)
+            df.to_excel(filename, index=False)
+            logging.warning(
+                f"Writer cancelled: partial output ({len(items)} items) "
+                f"written to {filename}"
+            )
+        else:
+            logging.warning(
+                "Writer cancelled before any items were written; no output file created"
+            )
+        raise
     except Exception as e:
         logging.error(f"Error writing to XLSX: {e}")
 
@@ -392,6 +445,20 @@ async def write_jsonl(queue, output_label, filename=None, limit=None, limit_reac
 
         tmp_filename.replace(filename)
         print(f"Data written to {filename}")
+    except asyncio.CancelledError:
+        # See write_csv's identical handling: rows already flushed to
+        # `tmp_filename` must not be stranded there silently on cancellation.
+        if items_written:
+            tmp_filename.replace(filename)
+            logging.warning(
+                f"Writer cancelled: partial output ({items_written} items) "
+                f"written to {filename}"
+            )
+        else:
+            logging.warning(
+                "Writer cancelled before any items were written; no output file created"
+            )
+        raise
     except Exception as e:
         logging.error(f"Error writing to JSONL: {e}")
 
@@ -674,12 +741,19 @@ async def main(args):
     # After scraping is done, put a sentinel value into the queue to signal the writer to finish
     await queue_.put(None)
 
-    # Wait for the writer to finish with a timeout
+    # Wait for the writer to finish, budget scaled to the remaining backlog.
+    # A flat 30s here cancels the writer mid-drain on a large queue; each
+    # writer's own CancelledError handling salvages what it can, but a
+    # timeout that scales with the actual backlog means that path is rarely
+    # needed in the first place.
+    drain_timeout = max(30, queue_.qsize() * 0.05 + 30)
     try:
-        await asyncio.wait_for(writer_task, timeout=30)
+        await asyncio.wait_for(writer_task, timeout=drain_timeout)
     except asyncio.TimeoutError:
-        logging.warning("Writer task took too long and was stopped")
+        logging.warning(f"Writer task took too long (>{drain_timeout:.0f}s) and was stopped")
         writer_task.cancel()
+        await asyncio.gather(writer_task, return_exceptions=True)
     except Exception as e:
         logging.error(f"Error in writer task: {e}")
         writer_task.cancel()
+        await asyncio.gather(writer_task, return_exceptions=True)

--- a/src/newswatch/main.py
+++ b/src/newswatch/main.py
@@ -7,11 +7,12 @@ import asyncio
 import csv
 import json
 import logging
+import math
 from datetime import datetime
 from pathlib import Path
 
 
-from .registry import get_available_scrapers_from_registry
+from .registry import get_available_scrapers_from_registry, get_scraper_by_slug
 
 logging.basicConfig(
     level=logging.INFO,
@@ -400,31 +401,64 @@ def get_available_scrapers(method="search"):
     return get_available_scrapers_from_registry(method=method)
 
 
+def _compute_outer_timeout(scraper_entries, max_concurrent_scrapers, scraper_timeout):
+    """Derive the outer batch timeout from how many waves the scraper cap forces.
+
+    Browser-required scrapers share a separate, smaller pool (see `main`), so
+    the two pools can need a different number of waves; the outer bound must
+    cover whichever pool takes longer.
+    """
+    browser_cap = min(2, max_concurrent_scrapers)
+    browser_count = sum(
+        1
+        for slug, _ in scraper_entries
+        if getattr(get_scraper_by_slug(slug), "browser_required", False)
+    )
+    general_count = len(scraper_entries) - browser_count
+
+    waves = 1
+    if general_count:
+        waves = max(waves, math.ceil(general_count / max_concurrent_scrapers))
+    if browser_count:
+        waves = max(waves, math.ceil(browser_count / browser_cap))
+
+    return waves * (scraper_timeout or 180) + 60
+
+
 async def _run_scraper_with_timeout(
-    scraper, name, index, total, method, timeout, progress
+    scraper, name, index, total, method, timeout, progress, sem
 ):
-    """Run a single scraper with optional timeout and progress logging."""
-    if progress:
-        print(f"[{index}/{total}] {name}: starting")
-    start_time = asyncio.get_event_loop().time()
-    try:
-        if timeout:
-            await asyncio.wait_for(scraper.scrape(method=method), timeout=timeout)
-        else:
-            await scraper.scrape(method=method)
-        elapsed = asyncio.get_event_loop().time() - start_time
+    """Run a single scraper under a concurrency-limiting semaphore, with
+    optional timeout and progress logging.
+
+    The semaphore is acquired *outside* the timeout window -- otherwise a
+    scraper queued behind the semaphore burns its own timeout budget just
+    waiting for a slot.
+    """
+    if progress and sem.locked():
+        print(f"[{index}/{total}] {name}: queued")
+    async with sem:
         if progress:
-            print(f"[{index}/{total}] {name}: done in {elapsed:.1f}s")
-        return "ok"
-    except asyncio.TimeoutError:
-        if progress:
-            print(f"[{index}/{total}] {name}: timed out after {timeout}s")
-        return "timeout"
-    except Exception as e:
-        elapsed = asyncio.get_event_loop().time() - start_time
-        if progress:
-            print(f"[{index}/{total}] {name}: error in {elapsed:.1f}s - {e}")
-        return "error"
+            print(f"[{index}/{total}] {name}: starting")
+        start_time = asyncio.get_event_loop().time()
+        try:
+            if timeout:
+                await asyncio.wait_for(scraper.scrape(method=method), timeout=timeout)
+            else:
+                await scraper.scrape(method=method)
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if progress:
+                print(f"[{index}/{total}] {name}: done in {elapsed:.1f}s")
+            return "ok"
+        except asyncio.TimeoutError:
+            if progress:
+                print(f"[{index}/{total}] {name}: timed out after {timeout}s")
+            return "timeout"
+        except Exception as e:
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if progress:
+                print(f"[{index}/{total}] {name}: error in {elapsed:.1f}s - {e}")
+            return "error"
 
 
 async def main(args):
@@ -497,7 +531,12 @@ async def main(args):
             name.strip().lower() for name in selected_scrapers.split(",")
         ]
 
-    scrapers = []
+    # (slug, instance) pairs, built together so the slug used for progress
+    # labels and semaphore selection can never desync from the instance list
+    # (the two were previously reconstructed separately and zipped
+    # positionally, which broke silently whenever a requested slug was
+    # unrecognized).
+    scraper_entries = []
     for scraper_name in scrapers_to_run:
         scraper_info = scraper_classes.get(scraper_name)
         if scraper_info:
@@ -512,9 +551,11 @@ async def main(args):
                     scraper_instance.max_pages = max_pages
                 else:
                     scraper_instance.max_latest_pages = max_pages
-            scrapers.append(scraper_instance)
+            scraper_entries.append((scraper_name, scraper_instance))
         else:
             logging.warning(f"scraper '{scraper_name}' is not recognized.")
+
+    scrapers = [instance for _, instance in scraper_entries]
 
     if not scrapers:
         logging.error("no valid scrapers selected. exiting.")
@@ -529,37 +570,59 @@ async def main(args):
     # Extract new CLI parameters
     scraper_timeout = getattr(args, "scraper_timeout", None)
     progress = getattr(args, "progress", False)
+    max_concurrent_scrapers = getattr(args, "max_concurrent_scrapers", None) or 6
 
-    # run all scrapers concurrently with per-scraper timeout and progress logging
-    scraper_names = list(scraper_classes.keys()) if selected_scrapers.lower() in ["all", "auto"] else scrapers_to_run
-    total = len(scrapers)
+    # Global cap on how many scrapers run at once (issue #47): with no cap,
+    # `--scrapers all` fires every registry entry as a concurrent task, and
+    # the browser-required ones each launch their own Chromium process on
+    # top of that. Browser-required scrapers share a separate, smaller pool
+    # since a Chromium launch is far heavier than a plain HTTP request.
+    general_sem = asyncio.Semaphore(max_concurrent_scrapers)
+    browser_sem = asyncio.Semaphore(min(2, max_concurrent_scrapers))
+
+    total = len(scraper_entries)
     progress_tasks = [
         asyncio.create_task(
             _run_scraper_with_timeout(
                 scraper,
-                scraper_names[i] if i < len(scraper_names) else f"scraper_{i}",
+                slug,
                 i + 1,
                 total,
                 method,
                 scraper_timeout,
                 progress,
+                browser_sem
+                if getattr(get_scraper_by_slug(slug), "browser_required", False)
+                else general_sem,
             )
         )
-        for i, scraper in enumerate(scrapers)
+        for i, (slug, scraper) in enumerate(scraper_entries)
     ]
+
+    # The outer wrapper is a backstop for tasks that swallow cancellation --
+    # each task already self-limits via its own per-scraper `wait_for`
+    # (scraper_timeout). It must NOT be a bare literal: with the cap above,
+    # scrapers run in waves rather than all at once, so total wall time is
+    # roughly (waves x scraper_timeout), not scraper_timeout alone. A fixed
+    # 180s here silently overrides --scraper-timeout and mass-cancels every
+    # scraper still waiting on a later wave, indistinguishable in the summary
+    # from ones that hit their own real timeout.
+    outer_timeout = _compute_outer_timeout(
+        scraper_entries, max_concurrent_scrapers, scraper_timeout
+    )
 
     if limit is not None:
         all_done = asyncio.gather(*progress_tasks)
         limit_hit = asyncio.create_task(limit_reached_event.wait())
         done, pending = await asyncio.wait(
-            [all_done, limit_hit], timeout=180, return_when=asyncio.FIRST_COMPLETED,
+            [all_done, limit_hit], timeout=outer_timeout, return_when=asyncio.FIRST_COMPLETED,
         )
         if not done:
             all_done.cancel()
             for t in progress_tasks:
                 if not t.done():
                     t.cancel()
-            logging.warning("Scraping took too long and was stopped after 180 seconds")
+            logging.warning(f"Scraping took too long and was stopped after {outer_timeout} seconds")
         elif limit_hit in done:
             all_done.cancel()
             for t in progress_tasks:
@@ -578,10 +641,10 @@ async def main(args):
     else:
         try:
             results = await asyncio.wait_for(
-                asyncio.gather(*progress_tasks), timeout=180
+                asyncio.gather(*progress_tasks), timeout=outer_timeout
             )
         except asyncio.TimeoutError:
-            logging.warning("Scraping took too long and was stopped after 180 seconds")
+            logging.warning(f"Scraping took too long and was stopped after {outer_timeout} seconds")
             for t in progress_tasks:
                 if not t.done():
                     t.cancel()

--- a/src/newswatch/registry.py
+++ b/src/newswatch/registry.py
@@ -6,7 +6,13 @@ Each entry declares:
   - name: human-readable display name
   - module: python module name (relative to scrapers/)
   - class_name: scraper class name
-  - concurrency: default worker count
+  - concurrency: default worker count (HTTP fetch concurrency, via self.fetch())
+  - keyword_concurrency: cap on concurrent keyword tasks per scraper run;
+    None means unbounded (default). Distinct axis from `concurrency` --
+    scrapers that call Playwright directly from fetch_search_results()
+    never go through self.fetch(), so `concurrency` doesn't bound them.
+    browser_required sources default to 1 here even when unset (see
+    get_available_scrapers_from_registry).
   - status: "stable" | "quarantined" | "investigating"
   - strict_search: whether true arbitrary-keyword search is validated
   - browser_required: whether Playwright is needed for this source
@@ -36,6 +42,7 @@ class ScraperEntry:
     module: str
     class_name: str
     concurrency: int = 5
+    keyword_concurrency: Optional[int] = None
     status: str = "stable"  # stable | quarantined | investigating
     strict_search: bool = True
     browser_required: bool = False
@@ -971,12 +978,16 @@ def get_available_scrapers_from_registry(method: str = "search"):
                 f".scrapers.{entry.module}", package="newswatch"
             )
             scraper_class = getattr(module, entry.class_name)
-            scraper_classes[slug] = {
-                "class": scraper_class,
-                "params": {"concurrency": entry.concurrency}
-                if entry.concurrency
-                else {},
-            }
+            params = {"concurrency": entry.concurrency} if entry.concurrency else {}
+            keyword_concurrency = entry.keyword_concurrency
+            if keyword_concurrency is None and entry.browser_required:
+                # Each browser-required scraper launches its own Chromium
+                # process per keyword task unless gated; default to serial
+                # keywords for these unless an entry opts into more.
+                keyword_concurrency = 1
+            if keyword_concurrency is not None:
+                params["keyword_concurrency"] = keyword_concurrency
+            scraper_classes[slug] = {"class": scraper_class, "params": params}
         except (ImportError, AttributeError) as e:
             logging.warning(f"Failed to load scraper '{slug}': {e}")
 

--- a/src/newswatch/scrapers/basescraper.py
+++ b/src/newswatch/scrapers/basescraper.py
@@ -17,8 +17,9 @@ class BaseScraper(AsyncScraper, ABC):
         start_datetime=None,
         end_datetime=None,
         max_pages=None,
+        keyword_concurrency=None,
     ):
-        super().__init__(concurrency)
+        super().__init__(concurrency, keyword_concurrency=keyword_concurrency)
         self.keywords = (
             [keyword.strip() for keyword in keywords.split(",") if keyword.strip()]
             if keywords
@@ -120,12 +121,17 @@ class BaseScraper(AsyncScraper, ABC):
         if not found_articles:
             logging.info(f"No latest news found on {self.base_url}")
 
+    async def _run_keyword(self, keyword):
+        if self.keyword_semaphore is None:
+            await self.fetch_search_results(keyword)
+        else:
+            async with self.keyword_semaphore:
+                await self.fetch_search_results(keyword)
+
     async def scrape(self, method="search"):
         async with self:
             if method == "latest":
                 await self.fetch_latest_results()
             else:
-                tasks = [
-                    self.fetch_search_results(keyword) for keyword in self.keywords
-                ]
+                tasks = [self._run_keyword(keyword) for keyword in self.keywords]
                 await self.run(tasks)

--- a/src/newswatch/scrapers/beritasatu.py
+++ b/src/newswatch/scrapers/beritasatu.py
@@ -23,8 +23,8 @@ class BeritaSatuScraper(BaseScraper):
     Latest: homepage for page 1, /page/{N} for later.
     """
 
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.beritasatu.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/bisnis.py
+++ b/src/newswatch/scrapers/bisnis.py
@@ -12,8 +12,8 @@ _UNSUPPORTED_SUBDOMAINS = {"epaper", "foto", "video", "infografis"}
 
 
 class BisnisScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=12, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=12, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "bisnis.com"
         self.start_date = start_date
 

--- a/src/newswatch/scrapers/ddtcnews.py
+++ b/src/newswatch/scrapers/ddtcnews.py
@@ -31,8 +31,8 @@ def _matches_keyword(keyword, title):
 class DDTCNewsScraper(BaseScraper):
     """Scrape DDTC News search results and article pages."""
 
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = BASE_URL
         self.start_date = start_date
         self.max_pages = 10

--- a/src/newswatch/scrapers/idntimes.py
+++ b/src/newswatch/scrapers/idntimes.py
@@ -15,8 +15,8 @@ from .basescraper import BaseScraper
 
 
 class IDNTimesScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.idntimes.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/jakartapost.py
+++ b/src/newswatch/scrapers/jakartapost.py
@@ -16,8 +16,8 @@ from .basescraper import BaseScraper
 
 
 class JakartaPostScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.thejakartapost.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/liputan6.py
+++ b/src/newswatch/scrapers/liputan6.py
@@ -15,8 +15,8 @@ from .basescraper import BaseScraper
 
 
 class Liputan6Scraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.liputan6.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/pikiranrakyat.py
+++ b/src/newswatch/scrapers/pikiranrakyat.py
@@ -16,8 +16,8 @@ from .basescraper import BaseScraper
 
 
 class PikiranRakyatScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.pikiran-rakyat.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/republika.py
+++ b/src/newswatch/scrapers/republika.py
@@ -15,8 +15,8 @@ from .basescraper import BaseScraper
 
 
 class RepublikaScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.republika.co.id"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/suara.py
+++ b/src/newswatch/scrapers/suara.py
@@ -25,8 +25,8 @@ from .basescraper import BaseScraper
 
 
 class SuaraScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=12, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=12, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://www.suara.com"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/scrapers/tirto.py
+++ b/src/newswatch/scrapers/tirto.py
@@ -15,8 +15,8 @@ from .basescraper import BaseScraper
 
 
 class TirtoScraper(BaseScraper):
-    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
-        super().__init__(keywords, concurrency, queue_)
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None, keyword_concurrency=None):
+        super().__init__(keywords, concurrency, queue_, keyword_concurrency=keyword_concurrency)
         self.base_url = "https://tirto.id"
         self.start_date = start_date
         self.continue_scraping = True

--- a/src/newswatch/utils.py
+++ b/src/newswatch/utils.py
@@ -97,8 +97,16 @@ def _looks_blocked(text: str) -> bool:
 
 
 class AsyncScraper:
-    def __init__(self, concurrency=12, max_retries=None):
+    def __init__(self, concurrency=12, max_retries=None, keyword_concurrency=None):
         self.semaphore = asyncio.Semaphore(concurrency)
+        # Separate from `semaphore` on purpose: `semaphore` is acquired again
+        # inside `fetch()`, so reusing it here would self-deadlock any
+        # scraper running at concurrency=1. `keyword_concurrency=None` means
+        # unbounded -- the historical behavior for scrapers that route
+        # through `fetch()` and are already throttled there.
+        self.keyword_semaphore = (
+            asyncio.Semaphore(keyword_concurrency) if keyword_concurrency else None
+        )
         self.session = None
         self.max_retries = max_retries if max_retries is not None else config.get_max_retries()
         self.proxy = config.get_proxy()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,12 +2,15 @@
 Tests for the synchronous API module.
 """
 
+import asyncio
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
 
+import newswatch.api as api_module
 from newswatch.api import (
     latest,
     latest_to_dataframe,
@@ -242,6 +245,7 @@ class TestConvenienceFunctions:
             limit=None,
             max_pages=None,
             scraper_timeout=None,
+            max_concurrent_scrapers=6,
             time_range=None,
             dedup_file=None,
             proxy=None,
@@ -266,6 +270,7 @@ class TestConvenienceFunctions:
             limit=None,
             max_pages=None,
             scraper_timeout=None,
+            max_concurrent_scrapers=6,
             time_range=None,
             dedup_file=None,
             proxy=None,
@@ -288,6 +293,7 @@ class TestConvenienceFunctions:
             limit=None,
             max_pages=None,
             scraper_timeout=None,
+            max_concurrent_scrapers=6,
             time_range=None,
             dedup_file=None,
             proxy=None,
@@ -469,6 +475,96 @@ class TestScraperTimeout:
         mock_scrape.return_value = []
         scrape_to_dataframe("test", "2025-01-01", scraper_timeout=20)
         mock_scrape.assert_called_once()
+
+
+def _make_tracking_scraper_class():
+    """A fake scraper class whose scrape() records peak concurrency of
+    instances of THIS class -- mirrors tests/test_main.py's helper of the
+    same name (duplicated on purpose; test modules here are standalone)."""
+
+    class _Tracking:
+        active = 0
+        max_active = 0
+
+        def __init__(self, keywords, start_date=None, queue_=None, **kwargs):
+            self.queue_ = queue_
+
+        async def scrape(self, method="search"):
+            cls = type(self)
+            cls.active += 1
+            cls.max_active = max(cls.max_active, cls.active)
+            await asyncio.sleep(0.05)
+            cls.active -= 1
+
+    return _Tracking
+
+
+class TestMaxConcurrentScrapers:
+    """Issue #47: the Python API path has its own scraper-dispatch loop
+    (main.py's fix does not cover it) and must cap concurrency too."""
+
+    def test_max_concurrent_scrapers_caps_general_pool(self, monkeypatch):
+        General = _make_tracking_scraper_class()
+        scraper_classes = {
+            f"general{i}": {"class": General, "params": {}} for i in range(8)
+        }
+        monkeypatch.setattr(
+            api_module, "get_available_scrapers", lambda method="search": scraper_classes
+        )
+        monkeypatch.setattr(
+            api_module,
+            "get_scraper_by_slug",
+            lambda slug: SimpleNamespace(browser_required=False),
+        )
+
+        # verbose=True: api.py's logging.disable(logging.CRITICAL) on the
+        # default (verbose=False) path is never restored afterward
+        # (pre-existing bug, out of scope here) -- verbose=True keeps this
+        # test from poisoning logging for tests that run later in the same
+        # process.
+        result = scrape(
+            "test", "2025-01-01", scrapers="all", verbose=True,
+            max_concurrent_scrapers=3,
+        )
+
+        assert result == []
+        assert General.max_active <= 3
+
+    def test_browser_required_scrapers_share_smaller_pool(self, monkeypatch):
+        General = _make_tracking_scraper_class()
+        Browser = _make_tracking_scraper_class()
+        scraper_classes = {
+            **{f"general{i}": {"class": General, "params": {}} for i in range(6)},
+            **{f"browser{i}": {"class": Browser, "params": {}} for i in range(6)},
+        }
+        monkeypatch.setattr(
+            api_module, "get_available_scrapers", lambda method="search": scraper_classes
+        )
+        monkeypatch.setattr(
+            api_module,
+            "get_scraper_by_slug",
+            lambda slug: SimpleNamespace(browser_required=slug.startswith("browser")),
+        )
+
+        result = scrape(
+            "test", "2025-01-01", scrapers="all", verbose=True,
+            max_concurrent_scrapers=6,
+        )
+
+        assert result == []
+        # Browser pool is capped at min(2, max_concurrent_scrapers)
+        # regardless of the general pool's larger cap.
+        assert Browser.max_active <= 2
+        assert General.max_active <= 6
+
+    @patch("newswatch.api._async_scrape_to_list", new_callable=AsyncMock)
+    def test_scrape_forwards_max_concurrent_scrapers_as_keyword(self, mock_async):
+        """Locks in keyword-only forwarding: a positional insertion would
+        silently shift the limit/max_pages indices asserted elsewhere
+        (TestMaxPagesPropagation, TestLimitRegression)."""
+        mock_async.return_value = []
+        scrape("test", "2025-01-01", max_concurrent_scrapers=4)
+        assert mock_async.call_args[1]["max_concurrent_scrapers"] == 4
 
 
 class TestAPIIntegration:

--- a/tests/test_basescraper.py
+++ b/tests/test_basescraper.py
@@ -46,3 +46,82 @@ async def test_fetch_search_results_with_max_pages_two_stops_after_page_two():
     scraper = _PaginationScraper("ihsg", queue_=asyncio.Queue(), max_pages=2)
     await scraper.fetch_search_results("ihsg")
     assert scraper.visited_pages == [1, 2]
+
+
+class _ConcurrencyTrackingScraper(BaseScraper):
+    """Mimics a browser-required scraper: fetch_search_results does its own
+    work directly, never calling self.fetch(), so only self.keyword_semaphore
+    (not self.semaphore) can bound how many keyword tasks run at once."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.active = 0
+        self.max_active = 0
+
+    async def build_search_url(self, keyword, page):
+        return None
+
+    def parse_article_links(self, response_text):
+        return []
+
+    async def get_article(self, link, keyword):
+        pass
+
+    async def fetch_search_results(self, keyword):
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.01)
+        self.active -= 1
+
+
+async def test_scrape_without_keyword_concurrency_runs_keywords_unbounded():
+    scraper = _ConcurrencyTrackingScraper(
+        "a,b,c,d,e", queue_=asyncio.Queue(), keyword_concurrency=None
+    )
+    assert scraper.keyword_semaphore is None
+    await scraper.scrape(method="search")
+    assert scraper.max_active == 5
+
+
+async def test_scrape_with_keyword_concurrency_one_runs_keywords_serially():
+    scraper = _ConcurrencyTrackingScraper(
+        "a,b,c,d,e", queue_=asyncio.Queue(), keyword_concurrency=1
+    )
+    await scraper.scrape(method="search")
+    assert scraper.max_active == 1
+
+
+async def test_scrape_with_keyword_concurrency_caps_parallel_keywords():
+    scraper = _ConcurrencyTrackingScraper(
+        "a,b,c,d,e,f", queue_=asyncio.Queue(), keyword_concurrency=2
+    )
+    await scraper.scrape(method="search")
+    assert scraper.max_active <= 2
+
+
+class _HttpPathScraper(BaseScraper):
+    """Routes through self.fetch() like most scrapers -- proves
+    keyword_concurrency=1 alongside concurrency=1 doesn't self-deadlock.
+    If keyword_semaphore reused self.semaphore, a single task would try to
+    acquire the same non-reentrant lock twice (once via _run_keyword, again
+    inside fetch()) and hang forever."""
+
+    async def build_search_url(self, keyword, page):
+        return await self.fetch("https://example.com")
+
+    def parse_article_links(self, response_text):
+        return []
+
+    async def get_article(self, link, keyword):
+        pass
+
+
+async def test_keyword_semaphore_distinct_from_fetch_semaphore_no_deadlock():
+    from aioresponses import aioresponses
+
+    scraper = _HttpPathScraper(
+        "a,b", concurrency=1, queue_=asyncio.Queue(), keyword_concurrency=1
+    )
+    with aioresponses() as mocked:
+        mocked.get("https://example.com", status=200, body="ok", repeat=True)
+        await asyncio.wait_for(scraper.scrape(method="search"), timeout=2)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,13 @@
+import asyncio
 import logging
 from argparse import Namespace
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
-from newswatch.main import _parse_time_range, main
+from newswatch import main as main_module
+from newswatch.main import _compute_outer_timeout, _parse_time_range, main
 
 
 @pytest.mark.asyncio
@@ -15,6 +18,108 @@ async def test_main_no_scrapers(caplog):
     )
     await main(args)
     assert "no valid scrapers selected. exiting." in caplog.text
+
+
+def _make_tracking_scraper_class():
+    """A fake scraper class whose scrape() records peak concurrency of
+    instances of THIS class -- a fresh class per test group keeps browser
+    vs. general pool counts independent."""
+
+    class _Tracking:
+        active = 0
+        max_active = 0
+
+        def __init__(self, keywords, start_date=None, queue_=None, **kwargs):
+            self.queue_ = queue_
+
+        async def scrape(self, method="search"):
+            cls = type(self)
+            cls.active += 1
+            cls.max_active = max(cls.max_active, cls.active)
+            await asyncio.sleep(0.05)
+            cls.active -= 1
+
+    return _Tracking
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_scrapers_caps_general_pool(tmp_path, monkeypatch):
+    General = _make_tracking_scraper_class()
+    scraper_classes = {
+        f"general{i}": {"class": General, "params": {}} for i in range(8)
+    }
+
+    monkeypatch.setattr(
+        main_module, "get_available_scrapers", lambda method="search": scraper_classes
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_scraper_by_slug",
+        lambda slug: SimpleNamespace(browser_required=False),
+    )
+
+    args = Namespace(
+        keywords="test",
+        start_date=None,
+        scrapers="all",
+        output_path=str(tmp_path / "out.csv"),
+        output_format="csv",
+        max_concurrent_scrapers=3,
+    )
+    await main(args)
+
+    assert General.max_active <= 3
+
+
+@pytest.mark.asyncio
+async def test_browser_required_scrapers_share_smaller_pool(tmp_path, monkeypatch):
+    General = _make_tracking_scraper_class()
+    Browser = _make_tracking_scraper_class()
+    scraper_classes = {
+        **{f"general{i}": {"class": General, "params": {}} for i in range(6)},
+        **{f"browser{i}": {"class": Browser, "params": {}} for i in range(6)},
+    }
+
+    monkeypatch.setattr(
+        main_module, "get_available_scrapers", lambda method="search": scraper_classes
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_scraper_by_slug",
+        lambda slug: SimpleNamespace(browser_required=slug.startswith("browser")),
+    )
+
+    args = Namespace(
+        keywords="test",
+        start_date=None,
+        scrapers="all",
+        output_path=str(tmp_path / "out.csv"),
+        output_format="csv",
+        max_concurrent_scrapers=6,
+    )
+    await main(args)
+
+    # Browser pool is capped at min(2, max_concurrent_scrapers) regardless of
+    # the general pool's larger cap (issue #47: Chromium launches are far
+    # heavier than a plain HTTP request and must not share the general pool).
+    assert Browser.max_active <= 2
+    assert General.max_active <= 6
+
+
+def test_compute_outer_timeout_scales_with_wave_count():
+    entries = [(f"s{i}", None) for i in range(12)]
+    # 12 scrapers, cap 3 -> 4 waves; scraper_timeout 100 -> 4*100+60
+    assert _compute_outer_timeout(entries, 3, 100) == 460
+
+
+def test_compute_outer_timeout_uses_180_default_when_no_scraper_timeout():
+    entries = [(f"s{i}", None) for i in range(3)]
+    # 3 scrapers, cap 3 -> 1 wave; no scraper_timeout -> falls back to 180
+    assert _compute_outer_timeout(entries, 3, None) == 240
+
+
+def test_compute_outer_timeout_never_below_one_wave_with_no_scrapers():
+    assert _compute_outer_timeout([], 6, 100) == 160
 
 def test_parse_time_range_multi_day_inclusive():
     """multi-day date-only range expands start to local midnight and end to 23:59:59.999999."""

--- a/tests/test_writer_reliability.py
+++ b/tests/test_writer_reliability.py
@@ -1,0 +1,118 @@
+"""Writer cancellation must promote whatever was collected, loudly, instead
+of silently losing it (D4: main.py's post-scraping drain can cancel a writer
+mid-run on a large backlog)."""
+
+import asyncio
+import csv
+import json
+import logging
+
+import pytest
+
+from newswatch.main import write_csv, write_json, write_jsonl, write_xlsx
+
+_ROW = {
+    "title": "t",
+    "publish_date": "2026-01-17 00:00:00",
+    "author": "a",
+    "content": "c",
+    "keyword": "k",
+    "category": "cat",
+    "source": "s",
+    "link": "https://example.com",
+}
+
+
+async def _cancel_after_consuming(task, queue, expected_items):
+    # Let the writer drain what's already queued, then cancel it while it's
+    # blocked waiting for the next (never-arriving) item -- this reproduces
+    # main.py cancelling the writer mid-drain.
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if queue.empty():
+            break
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_write_csv_promotes_partial_output_on_cancellation(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_ROW)
+    await queue.put(_ROW)
+
+    out_path = tmp_path / "out.csv"
+    task = asyncio.create_task(write_csv(queue, output_label="test", filename=str(out_path)))
+    await _cancel_after_consuming(task, queue, 2)
+
+    assert out_path.exists()
+    with open(out_path, newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2
+    assert "partial output (2 items)" in caplog.text
+
+
+async def test_write_jsonl_promotes_partial_output_on_cancellation(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_ROW)
+
+    out_path = tmp_path / "out.jsonl"
+    task = asyncio.create_task(write_jsonl(queue, output_label="test", filename=str(out_path)))
+    await _cancel_after_consuming(task, queue, 1)
+
+    assert out_path.exists()
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["title"] == "t"
+    assert "partial output (1 items)" in caplog.text
+
+
+async def test_write_json_promotes_partial_output_on_cancellation(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_ROW)
+    await queue.put(_ROW)
+
+    out_path = tmp_path / "out.json"
+    task = asyncio.create_task(write_json(queue, output_label="test", filename=str(out_path)))
+    await _cancel_after_consuming(task, queue, 2)
+
+    assert out_path.exists()
+    articles = json.loads(out_path.read_text(encoding="utf-8"))
+    assert len(articles) == 2
+    assert "partial output (2 items)" in caplog.text
+
+
+async def test_write_xlsx_promotes_partial_output_on_cancellation(tmp_path, caplog):
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("openpyxl")
+    caplog.set_level(logging.WARNING)
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(_ROW)
+
+    out_path = tmp_path / "out.xlsx"
+    task = asyncio.create_task(write_xlsx(queue, output_label="test", filename=str(out_path)))
+    await _cancel_after_consuming(task, queue, 1)
+
+    assert out_path.exists()
+    df = pd.read_excel(out_path)
+    assert len(df) == 1
+    assert "partial output (1 items)" in caplog.text
+
+
+async def test_write_csv_cancelled_before_any_item_creates_no_file(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    out_path = tmp_path / "out.csv"
+    task = asyncio.create_task(write_csv(queue, output_label="test", filename=str(out_path)))
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not out_path.exists()
+    assert "before any items were written" in caplog.text


### PR DESCRIPTION
## Summary
- close #47: no global cap on concurrent scrapers — `--scrapers all` fired all 72 as concurrent tasks, 9 launching their own Chromium, hung an 11-core laptop within seconds
- fix keyword-level semaphore bypass: 8 of 9 browser-required scrapers never acquired `self.semaphore`, so registry `concurrency=` was decorative; N keywords spawned N concurrent Chromium processes
- fix outer batch timeout hardcoded to 180s, silently overriding `--scraper-timeout`
- fix writer silently dropping rows: xlsx's 30s idle bail, and `CancelledError` bypassing each writer's cleanup on the post-scraping drain timeout
- fix the Python API path (`scrape`, `scrape_to_dataframe`, `scrape_to_file`, `latest*`): it has its own scraper-dispatch loop, so `nw.scrape(scrapers="all")` still reproduced #47 after the CLI fix

Land together — do not cherry-pick. D1 changes what a correct outer timeout is (D3 must follow); D3 must land before D2 or the old 180s cap mass-cancels every browser scraper once keywords run serially. The API fix depends on D2's registry changes.

## What's new
- `--max-concurrent-scrapers` / `max_concurrent_scrapers=` (default 6): general pool + separate smaller pool (max 2) for `browser_required` sources, on both CLI and API
- outer timeout now derived from wave count (`waves * scraper_timeout + margin`) instead of a flat 180s
- new `keyword_semaphore`, distinct from `semaphore` (reusing it would self-deadlock HTTP scrapers at `concurrency=1`); registry gets a `keyword_concurrency` field, default 1 for `browser_required`
- writers promote partial output with a loud warning on cancellation instead of losing collected rows; drain timeout scales with queue backlog
- API path warns (`warnings.warn`) when the overall `timeout` truncates a run, since `logging.disable` on the default `verbose=False` path swallows the existing log line
- docs updated across README, architecture, troubleshooting, getting-started, practical-guide, use-case-mbg, api-reference, and changelog

## Tests
- `uv run --extra dev pytest tests/ -m "not network" --timeout=30 -q` — 1204 passed, 21 skipped, 224 deselected (17 new: CLI concurrency cap, keyword gate + deadlock regression, outer-timeout calc, writer-cancellation partial output, API concurrency cap + keyword-forwarding regression)
- `uv run --extra dev ruff check` — passed
- `make sources-check` — passed
- `uv lock --check` — passed

## Notes
- manual verification pending on the machine that hung: Chromium main-process count under `-s all` with the cap, `-s idntimes` at 20+ keywords, mid-drain cancellation leaving no stranded `.tmp`
- `api.py`'s `logging.disable(logging.CRITICAL)` is never restored on the default path (pre-existing, unrelated to #47) — separate issue, not fixed here
