### PR TITLE
chore: prepare release 1.2.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - name: "Okky Mabruri"
     website: "okkymabruri.github.io"
     orcid: "https://orcid.org/0000-0002-2103-1311"
-version: 1.2.3
+version: 1.2.4
 abstract: "news-watch: Indonesia's top news websites scraper. A Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 publisher: Zenodo
 doi: "10.5281/zenodo.14908389"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-07-27
+
 ### Added
 - `--max-concurrent-scrapers` CLI flag and `max_concurrent_scrapers=` Python keyword (default 6) capping how many scrapers run at once; browser-required sources share a separate pool capped at 2
 - `keyword_concurrency` registry field (default 1 for browser-required sources) bounding concurrent per-keyword tasks within one scraper run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "news-watch"
-version = "1.2.3"
+version = "1.2.4"
 description = "news-watch is a Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/newswatch/__init__.py
+++ b/src/newswatch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 # health report
 from .health import health_report as health_report

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "news-watch"
-version = "1.2.3"
+version = "1.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump version 1.2.3 -> 1.2.4 (pyproject.toml, __init__.py, CITATION.cff, uv.lock)
- add changelog section for 1.2.4, covering PR #48's four fixes (issue #47 concurrency cap, keyword-semaphore gate, wave-based outer timeout, writer partial-output on cancellation)

## Validation
- `make release-validate VERSION=1.2.4` — passed
- `uv run --extra dev ruff check` — passed
- `uv run --extra dev pytest tests/ -m "not network" --timeout=30 -q` — 1204 passed, 21 skipped, 224 deselected
- `make sources-check` — passed
- `uv lock --check` — passed