### PR TITLE
feat: normalize publish timestamps to one timezone, add ABC News and NBC News

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ df = nw.scrape_to_dataframe(
 )
 ```
 
-Other reliability overrides (env vars): `NEWSWATCH_USER_AGENT` (custom User-Agent), `NEWSWATCH_MAX_RETRIES` (retry count, default 3).
+Other reliability overrides (env vars): `NEWSWATCH_USER_AGENT` (custom User-Agent), `NEWSWATCH_MAX_RETRIES` (retry count, default 3), `NEWSWATCH_TIMEZONE` (zone for `publish_date` and date filters, default `Asia/Jakarta`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ The output file contains the following columns:
 - `latest` is intended for latest-news monitoring and does not require keywords.
 
 <!-- BEGIN GENERATED: readme-heading -->
-## Supported Websites (79)
+## Supported Websites (81)
 <!-- END GENERATED: readme-heading -->
 <!-- BEGIN GENERATED: readme-sources -->
+[ABC News](https://abcnews.com),
 [Alinea.id](https://www.alinea.id),
 [Al Jazeera](https://www.aljazeera.com),
 [Antara News](https://antaranews.com),
@@ -217,6 +218,7 @@ The output file contains the following columns:
 [MetroTV News](https://metrotvnews.com),
 [Mojok](https://mojok.co),
 [Mongabay Indonesia](https://mongabay.co.id),
+[NBC News](https://www.nbcnews.com),
 [Niaga.Asia](https://www.niaga.asia),
 [NTVNews.id](https://www.ntvnews.id),
 [NusaBali](https://www.nusabali.com),
@@ -247,8 +249,8 @@ The output file contains the following columns:
 
 <!-- BEGIN GENERATED: readme-counts -->
 > **Notes:**
-> - 79 registered sources: 74 with keyword search, 79 with latest mode.
-> - 77 stable scrapers in the current release: 72 with keyword search, 77 with latest mode.
+> - 81 registered sources: 76 with keyword search, 81 with latest mode.
+> - 79 stable scrapers in the current release: 74 with keyword search, 79 with latest mode.
 > - 1 source under investigation; 1 source quarantined.
 > - AP News uses topic hub pages with keyword-in-title filtering (robots disallows /search?q=*).
 > - Al Jazeera is latest-only via RSS feed (search page is JS-rendered).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -196,13 +196,13 @@ except NewsWatchError as exc:
 <!-- BEGIN GENERATED: api-notes -->
 ## Stable API Notes
 
-All 79 registered scrapers are exposed via `list_scrapers()` and the public `SCRAPERS` mapping. 74 of them support the `search` method; all 79 support `latest`.
+All 81 registered scrapers are exposed via `list_scrapers()` and the public `SCRAPERS` mapping. 76 of them support the `search` method; all 81 support `latest`.
 
 ## Notes
 
 - Prefer `scrapers="auto"` unless you know which sites you need.
 - Cloud/server environments are more likely to be blocked.
-- Stable support currently covers 77 scrapers (72 search-capable, 77 latest-capable).
+- Stable support currently covers 79 scrapers (74 search-capable, 79 latest-capable).
 - 1 source under investigation; 1 source quarantined.
 
 **Empty results**: Check if your keywords are in Indonesian or try broader terms.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,8 +80,8 @@ bypass `fetch()` are bounded by the second.
 
 | State | Count |
 |---|---|
-| registered | 79 |
-| stable | 77 |
+| registered | 81 |
+| stable | 79 |
 | quarantined | 1 |
 | investigating | 1 |
 <!-- END GENERATED: architecture-state -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ flowchart TD
 | `cli.py` | CLI entry point |
 | `scrapers/basescraper.py` | Abstract contract — `build_search_url`, `parse_article_links`, `get_article` |
 | `utils.py` | `AsyncScraper` — request and keyword concurrency, WAF fallback (aiohttp → rnet → Playwright) |
+| `timeutils.py` | `to_project_naive` — single conversion point putting every source's `publish_date` on one clock |
 
 ## Retrieval Methods
 
@@ -74,6 +75,23 @@ bounds concurrent per-keyword tasks in `BaseScraper.scrape()` and is sized from
 the registry's `keyword_concurrency`, which defaults to 1 for browser-required
 sources. Only `fetch()` observes the first, so browser-driven scrapers that
 bypass `fetch()` are bounded by the second.
+
+## Timezone Convention
+
+`publish_date` is a naive datetime, and every source must agree on what naive
+means — otherwise one output file carries two clocks and the date filters
+compare across them. That reference zone is `Asia/Jakarta`, overridable with
+`NEWSWATCH_TIMEZONE`.
+
+`timeutils.to_project_naive` is the single conversion point. Offsets are
+converted into the reference zone, never discarded: an article published at
+`08:00-04:00` and one published at `08:00+07:00` are eleven hours apart and must
+not collapse onto the same timestamp. Values that arrive without an offset are
+taken to already be in the reference zone and pass through unchanged, which is
+why sources publishing at +07:00 are unaffected.
+
+`--start_date` and `--time_range` bounds are interpreted in the same zone, so a
+date-only range means local calendar days.
 
 <!-- BEGIN GENERATED: architecture-state -->
 ## Current State

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NEWSWATCH_TIMEZONE` environment variable setting the zone that naive `publish_date` values and `--time_range` boundaries are expressed in (default `Asia/Jakarta`)
 
 ### Changed
-- Publish timestamps from sources that report a UTC offset are now converted into the reference timezone instead of having the offset discarded, so every source in one output file shares a single clock. Timestamps from BBC, The Conversation Indonesia, Independen and IDN Financials shift accordingly; sources that publish at +07:00 are unaffected
+- Publish timestamps that carry a UTC offset are now converted into the reference timezone instead of having the offset discarded, so every source in one output file shares a single clock. Any source reporting an offset other than `+07:00` shifts by the difference — in practice the global English-language sources (BBC, AP News, Al Jazeera, and the two added here) plus The Conversation Indonesia, Independen and IDN Financials. Sources that publish at `+07:00`, or with no offset at all, are unaffected
 
 ### Fixed
 - `--time_range` no longer discards the entire output file when an article timestamp carries a UTC offset. The comparison raised `TypeError`, which escaped the parse guard: the CLI logged one line and never promoted its temporary file, while the Python API propagated the error

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ABC News and NBC News sources, both English-language. ABC filters the `xmlLatestStories` news sitemap (~13-day window); NBC walks its monthly archive pages, giving keyword search real historical reach
+- `NEWSWATCH_TIMEZONE` environment variable setting the zone that naive `publish_date` values and `--time_range` boundaries are expressed in (default `Asia/Jakarta`)
+
+### Changed
+- Publish timestamps from sources that report a UTC offset are now converted into the reference timezone instead of having the offset discarded, so every source in one output file shares a single clock. Timestamps from BBC, The Conversation Indonesia, Independen and IDN Financials shift accordingly; sources that publish at +07:00 are unaffected
+
+### Fixed
+- `--time_range` no longer discards the entire output file when an article timestamp carries a UTC offset. The comparison raised `TypeError`, which escaped the parse guard: the CLI logged one line and never promoted its temporary file, while the Python API propagated the error
+- IDN Financials timestamps no longer depend on the machine running the scraper
+
 ## [1.2.4] - 2026-07-27
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 <!-- BEGIN GENERATED: index-summary -->
 news-watch scrapes structured news data from Indonesia's top news websites with keyword/date search and latest-news monitoring.
 
-The current stable release supports 77 news scrapers (72 Indonesian/global sources with search mode, 77 with latest mode). 79 sources are registered in total: 1 source under investigation; 1 source quarantined.
+The current stable release supports 79 news scrapers (74 Indonesian/global sources with search mode, 79 with latest mode). 81 sources are registered in total: 1 source under investigation; 1 source quarantined.
 <!-- END GENERATED: index-summary -->
 
 ## Install

--- a/docs/practical-guide.md
+++ b/docs/practical-guide.md
@@ -56,10 +56,10 @@ nw.list_scrapers(method="latest") # sources that support latest mode
 For larger sweeps, narrow the date window or `--limit` to bound cost; for noisy periods, narrow `--scrapers` before retrying.
 
 <!-- BEGIN GENERATED: guide-counts -->
-The stable release currently exposes 77 supported scrapers. 1 source under investigation; 1 source quarantined.
+The stable release currently exposes 79 supported scrapers. 1 source under investigation; 1 source quarantined.
 
-72 of 77 stable sources support keyword search; 77 support latest monitoring.
-The full registry contains 79 sources: 74 support keyword search and 79 support latest monitoring.
+74 of 79 stable sources support keyword search; 79 support latest monitoring.
+The full registry contains 81 sources: 76 support keyword search and 81 support latest monitoring.
 <!-- END GENERATED: guide-counts -->
 
 ## Saving results

--- a/docs/practical-guide.md
+++ b/docs/practical-guide.md
@@ -116,6 +116,7 @@ newswatch --keywords ihsg --start_date 2025-01-01 --dedup-file previous-output.c
 export NEWSWATCH_PROXY="socks5://proxy.example.com:1080"
 export NEWSWATCH_USER_AGENT="Mozilla/5.0 ..."
 export NEWSWATCH_MAX_RETRIES=3
+export NEWSWATCH_TIMEZONE="Asia/Jakarta"
 newswatch --keywords ihsg --start_date 2025-01-01
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,6 +65,7 @@ Optional environment controls:
 
 - `NEWSWATCH_USER_AGENT`: custom user agent
 - `NEWSWATCH_MAX_RETRIES`: request retry limit; default 3
+- `NEWSWATCH_TIMEZONE`: zone that `publish_date` values and `--start_date`/`--time_range` boundaries are expressed in; default `Asia/Jakarta`
 
 ## Browser-backed source fails
 

--- a/scripts/generate_sources.py
+++ b/scripts/generate_sources.py
@@ -26,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # this on every run so a stale mapping fails fast instead of silently
 # dropping a source link.
 SOURCE_URLS: Dict[str, str] = {
+    "abcnews": "https://abcnews.com",
     "alinea": "https://www.alinea.id",
     "antaranews": "https://antaranews.com",
     "apnews": "https://apnews.com",
@@ -80,6 +81,7 @@ SOURCE_URLS: Dict[str, str] = {
     "niagaasia": "https://www.niaga.asia",
     "mojok": "https://mojok.co",
     "mongabay": "https://mongabay.co.id",
+    "nbcnews": "https://www.nbcnews.com",
     "nusabali": "https://www.nusabali.com",
     "ntvnews": "https://www.ntvnews.id",
     "okezone": "https://okezone.com",

--- a/src/newswatch/api.py
+++ b/src/newswatch/api.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from .exceptions import NewsWatchError, ValidationError
 from .main import get_available_scrapers
-from .main import _load_dedup_links, _parse_time_range
+from .main import _in_time_range, _load_dedup_links, _parse_time_range
 from .registry import get_scraper_by_slug
 
 
@@ -132,18 +132,8 @@ async def _collect_queue_results(
         # Apply time range filter
         if time_start is not None or time_end is not None:
             pub_date = item.get("publish_date")
-            if pub_date:
-                if isinstance(pub_date, str):
-                    try:
-                        pub_date = datetime.fromisoformat(pub_date)
-                    except ValueError:
-                        continue
-                if not isinstance(pub_date, datetime):
-                    continue
-                if time_start is not None and pub_date < time_start:
-                    continue
-                if time_end is not None and pub_date > time_end:
-                    continue
+            if pub_date and not _in_time_range(pub_date, time_start, time_end):
+                continue
 
         # format datetime objects as strings for json serialization
         if isinstance(item.get("publish_date"), datetime):

--- a/src/newswatch/config.py
+++ b/src/newswatch/config.py
@@ -1,6 +1,7 @@
 """Runtime config read from env. Single source for proxy/UA/retry overrides."""
 
 import os
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -8,6 +9,7 @@ DEFAULT_USER_AGENT = (
     "Chrome/126.0.0.0 Safari/537.36"
 )
 DEFAULT_MAX_RETRIES = 3
+DEFAULT_TIMEZONE = "Asia/Jakarta"
 
 
 def get_proxy():
@@ -41,6 +43,23 @@ def get_max_retries():
     if parsed < 0:
         return DEFAULT_MAX_RETRIES
     return parsed
+
+def get_timezone():
+    """IANA zone that naive publish timestamps are expressed in.
+
+    Reads ``NEWSWATCH_TIMEZONE``. Unset, empty, or not a known zone →
+    DEFAULT_TIMEZONE. Every source converts into this zone, so changing it
+    changes what a naive ``publish_date`` and a ``--time_range`` boundary mean.
+    """
+    value = os.environ.get("NEWSWATCH_TIMEZONE")
+    if not value:
+        return DEFAULT_TIMEZONE
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError):
+        return DEFAULT_TIMEZONE
+    return value
+
 
 def get_health_history_path() -> str | None:
     """Path for append-only JSONL health history, or None.

--- a/src/newswatch/main.py
+++ b/src/newswatch/main.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 
 from .registry import get_available_scrapers_from_registry, get_scraper_by_slug
+from .timeutils import to_project_naive
 
 logging.basicConfig(
     level=logging.INFO,
@@ -59,6 +60,29 @@ def _load_dedup_links(file_path: str) -> set:
 
     logger.info(f"Loaded {len(links)} links from dedup file: {file_path}")
     return links
+
+
+def _in_time_range(pub_date, time_start, time_end):
+    """True if ``pub_date`` falls inside the range; False if it can't be compared.
+
+    Range bounds are naive, so an offset-bearing value has to be converted onto
+    the same clock first -- comparing aware against naive raises TypeError,
+    which is not a ValueError and so escapes the caller's parse guard and kills
+    the whole writer.
+    """
+    if isinstance(pub_date, str):
+        try:
+            pub_date = datetime.fromisoformat(pub_date)
+        except ValueError:
+            return False
+    pub_date = to_project_naive(pub_date)
+    if not isinstance(pub_date, datetime):
+        return False
+    if time_start is not None and pub_date < time_start:
+        return False
+    if time_end is not None and pub_date > time_end:
+        return False
+    return True
 
 
 def _parse_time_range(time_range: str):
@@ -152,18 +176,8 @@ async def write_csv(queue, output_label, filename=None, limit=None, limit_reache
                 # Apply time range filter
                 if time_start is not None or time_end is not None:
                     pub_date = item.get("publish_date")
-                    if pub_date:
-                        if isinstance(pub_date, str):
-                            try:
-                                pub_date = datetime.fromisoformat(pub_date)
-                            except ValueError:
-                                continue
-                        if not isinstance(pub_date, datetime):
-                            continue
-                        if time_start is not None and pub_date < time_start:
-                            continue
-                        if time_end is not None and pub_date > time_end:
-                            continue
+                    if pub_date and not _in_time_range(pub_date, time_start, time_end):
+                        continue
 
                 # Format datetime objects as strings
                 if isinstance(item.get("publish_date"), datetime):
@@ -231,18 +245,8 @@ async def write_json(queue, output_label, filename=None, limit=None, limit_reach
             # Apply time range filter
             if time_start is not None or time_end is not None:
                 pub_date = item.get("publish_date")
-                if pub_date:
-                    if isinstance(pub_date, str):
-                        try:
-                            pub_date = datetime.fromisoformat(pub_date)
-                        except ValueError:
-                            continue
-                    if not isinstance(pub_date, datetime):
-                        continue
-                    if time_start is not None and pub_date < time_start:
-                        continue
-                    if time_end is not None and pub_date > time_end:
-                        continue
+                if pub_date and not _in_time_range(pub_date, time_start, time_end):
+                    continue
 
             # Format datetime objects as strings for JSON serialization
             if isinstance(item.get("publish_date"), datetime):
@@ -337,18 +341,8 @@ async def write_xlsx(queue, output_label, filename=None, limit=None, limit_reach
             # Apply time range filter
             if time_start is not None or time_end is not None:
                 pub_date = item.get("publish_date")
-                if pub_date:
-                    if isinstance(pub_date, str):
-                        try:
-                            pub_date = datetime.fromisoformat(pub_date)
-                        except ValueError:
-                            continue
-                    if not isinstance(pub_date, datetime):
-                        continue
-                    if time_start is not None and pub_date < time_start:
-                        continue
-                    if time_end is not None and pub_date > time_end:
-                        continue
+                if pub_date and not _in_time_range(pub_date, time_start, time_end):
+                    continue
 
             # Format datetime objects as strings
             if isinstance(item.get("publish_date"), datetime):
@@ -416,18 +410,8 @@ async def write_jsonl(queue, output_label, filename=None, limit=None, limit_reac
                 # Apply time range filter
                 if time_start is not None or time_end is not None:
                     pub_date = item.get("publish_date")
-                    if pub_date:
-                        if isinstance(pub_date, str):
-                            try:
-                                pub_date = datetime.fromisoformat(pub_date)
-                            except ValueError:
-                                continue
-                        if not isinstance(pub_date, datetime):
-                            continue
-                        if time_start is not None and pub_date < time_start:
-                            continue
-                        if time_end is not None and pub_date > time_end:
-                            continue
+                    if pub_date and not _in_time_range(pub_date, time_start, time_end):
+                        continue
 
                 # Format datetime objects as strings
                 if isinstance(item.get("publish_date"), datetime):

--- a/src/newswatch/registry.py
+++ b/src/newswatch/registry.py
@@ -839,7 +839,7 @@ _SCRAPER_ENTRIES: Tuple[ScraperEntry, ...] = (
         concurrency=3,
         smoke_keyword="police",
         supports_latest=True,
-        note="new; monthly /archive/articles/{year}/{month} keyword filtering for search (historical reach), /sitemap/nbcnews/sitemap-news for latest; robots disallows /search; English; 2026-07-27",
+        note="new; monthly /archive/articles/{year}/{month} keyword filtering for search (historical reach, at most 12 months and 25 articles per keyword per run, both logged when they bind), /sitemap/nbcnews/sitemap-news for latest; robots disallows /search; English; 2026-07-27",
     ),
 )
 

--- a/src/newswatch/registry.py
+++ b/src/newswatch/registry.py
@@ -819,6 +819,28 @@ _SCRAPER_ENTRIES: Tuple[ScraperEntry, ...] = (
         supports_latest=True,
         note="new; latest-only via RSS /xml/rss/all.xml; JS-rendered search page; English; global coverage; 2026-05-24",
     ),
+    ScraperEntry(
+        "abcnews",
+        "ABC News",
+        "abcnews", "ABCNewsScraper",
+        status="stable",
+        strict_search=False,
+        concurrency=3,
+        smoke_keyword="police",
+        supports_latest=True,
+        note="new; xmlLatestStories news sitemap keyword filtering (~13-day window); robots disallows /search?searchtext=*; abcnews.go.com 301s to abcnews.com; English; 2026-07-27",
+    ),
+    ScraperEntry(
+        "nbcnews",
+        "NBC News",
+        "nbcnews", "NBCNewsScraper",
+        status="stable",
+        strict_search=False,
+        concurrency=3,
+        smoke_keyword="police",
+        supports_latest=True,
+        note="new; monthly /archive/articles/{year}/{month} keyword filtering for search (historical reach), /sitemap/nbcnews/sitemap-news for latest; robots disallows /search; English; 2026-07-27",
+    ),
 )
 
 

--- a/src/newswatch/scrapers/__init__.py
+++ b/src/newswatch/scrapers/__init__.py
@@ -1,4 +1,6 @@
 from .antaranews import AntaranewsScraper as AntaranewsScraper
+from .abcnews import ABCNewsScraper as ABCNewsScraper
+from .nbcnews import NBCNewsScraper as NBCNewsScraper
 from .apnews import APNewsScraper as APNewsScraper
 from .aljazeera import AlJazeeraScraper as AlJazeeraScraper
 from .balipost import BaliPostScraper as BaliPostScraper

--- a/src/newswatch/scrapers/abcnews.py
+++ b/src/newswatch/scrapers/abcnews.py
@@ -1,0 +1,323 @@
+"""
+ABC News (abcnews.com) scraper — news-sitemap driven.
+
+Verified endpoints (2026-07-27):
+    feed:    https://abcnews.com/xmlLatestStories   (urlset, 1000 entries,
+             ~13-day window, each with <loc>, <lastmod>, <news:title> and
+             <news:publication_date>)
+    article: https://abcnews.com/<Section>/<kind>/<slug>-<id>
+
+abcnews.go.com issues a 301 to abcnews.com, so the canonical host is
+abcnews.com. robots.txt disallows /search?searchtext=*, so keyword search
+filters the news sitemap rather than hitting the site's search endpoint —
+the same approach detik and idxchannel take. Because the feed carries a
+publication date per entry, the start_date cutoff is applied before any
+article is fetched.
+"""
+import re
+import xml.etree.ElementTree as ET
+import logging
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from .basescraper import BaseScraper
+
+_SM_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_NEWS_NS = "http://www.google.com/schemas/sitemap-news/0.9"
+_NSMAP = {"sm": _SM_NS, "news": _NEWS_NS}
+
+_BASE_URL = "https://abcnews.com"
+_FEED_URL = f"{_BASE_URL}/xmlLatestStories"
+
+_ALLOWED_HOSTS = ("abcnews.com", "www.abcnews.com", "abcnews.go.com")
+
+# Section landing pages and non-article surfaces carry no story body.
+_NON_ARTICLE_RE = re.compile(
+    r"/(?:video|videos|live|photos|Photos)(?:/|$)",
+    re.IGNORECASE,
+)
+
+
+def _normalize(text):
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _keyword_tokens(keyword):
+    return [tok for tok in re.split(r"\W+", (keyword or "").lower()) if len(tok) > 1]
+
+
+def _matches_all_tokens(haystack, tokens):
+    if not tokens:
+        return True
+    if not haystack:
+        return False
+    return all(re.search(rf"\b{re.escape(tok)}\b", haystack) for tok in tokens)
+
+
+def _is_article_url(url):
+    """Accept same-site /<Section>/<...>/<slug> URLs, reject video/photo surfaces."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if (parsed.netloc or "").lower() not in _ALLOWED_HOSTS:
+        return False
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) < 2:
+        return False
+    return not _NON_ARTICLE_RE.search(parsed.path)
+
+
+class ABCNewsScraper(BaseScraper):
+    """ABC News adapter driven by the xmlLatestStories news sitemap."""
+
+    BASE_URL = _BASE_URL
+    FEED_URL = _FEED_URL
+    SOURCE_LABEL = "abcnews.com"
+    MAX_ARTICLES_PER_QUERY = 25
+
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
+        super().__init__(keywords, concurrency, queue_)
+        self.base_url = self.BASE_URL
+        self.start_date = start_date
+        self._current_keyword = ""
+        self.headers = {"Accept-Language": "en-US,en;q=0.9"}
+
+    # ------------------------------------------------------------------
+    # Feed parsing
+    # ------------------------------------------------------------------
+    def _parse_feed(self, response_text):
+        """Return [(loc, title, publish_date)] from the news sitemap urlset."""
+        if not response_text:
+            return []
+        head = response_text.lstrip()[:64].lower()
+        if not head.startswith("<?xml") and "<urlset" not in head:
+            return []
+        try:
+            root = ET.fromstring(response_text)
+        except ET.ParseError as e:
+            logging.error("ABC News sitemap parse error: %s", e)
+            return []
+        if root.tag != f"{{{_SM_NS}}}urlset":
+            return []
+
+        entries = []
+        for url in root.findall("sm:url", _NSMAP):
+            loc = (url.findtext("sm:loc", "", _NSMAP) or "").strip()
+            if not loc or not _is_article_url(loc):
+                continue
+            title = ""
+            raw_date = ""
+            news = url.find("news:news", _NSMAP)
+            if news is not None:
+                title = (news.findtext("news:title", "", _NSMAP) or "").strip()
+                raw_date = (
+                    news.findtext("news:publication_date", "", _NSMAP) or ""
+                ).strip()
+            if not raw_date:
+                raw_date = (url.findtext("sm:lastmod", "", _NSMAP) or "").strip()
+            entries.append((loc, title, self.parse_date(raw_date) if raw_date else None))
+        return entries
+
+    async def _fetch_feed(self):
+        text = await self.fetch(self.FEED_URL, headers=self.headers, timeout=30)
+        return self._parse_feed(text)
+
+    def _select(self, entries, tokens):
+        """Filter feed entries by keyword tokens and the start_date cutoff."""
+        links = []
+        seen = set()
+        for loc, title, publish_date in entries:
+            if self.start_date and publish_date and publish_date < self.start_date:
+                continue
+            if tokens and not _matches_all_tokens(_normalize(f"{title} {loc}"), tokens):
+                continue
+            if loc in seen:
+                continue
+            links.append(loc)
+            seen.add(loc)
+            if len(links) >= self.MAX_ARTICLES_PER_QUERY:
+                break
+        return links or None
+
+    # ------------------------------------------------------------------
+    # Search path
+    # ------------------------------------------------------------------
+    async def build_search_url(self, keyword, page):
+        self._current_keyword = keyword or ""
+        if page != 1:
+            return None
+        return await self._fetch_feed()
+
+    def parse_article_links(self, response_text_or_entries):
+        if not response_text_or_entries:
+            return None
+        entries = (
+            self._parse_feed(response_text_or_entries)
+            if isinstance(response_text_or_entries, str)
+            else response_text_or_entries
+        )
+        return self._select(entries, _keyword_tokens(self._current_keyword))
+
+    # ------------------------------------------------------------------
+    # Latest path
+    # ------------------------------------------------------------------
+    async def build_latest_url(self, page):
+        if page != 1:
+            return None
+        return await self._fetch_feed()
+
+    def parse_latest_article_links(self, response_text_or_entries):
+        if not response_text_or_entries:
+            return None
+        entries = (
+            self._parse_feed(response_text_or_entries)
+            if isinstance(response_text_or_entries, str)
+            else response_text_or_entries
+        )
+        return self._select(entries, [])
+
+    # ------------------------------------------------------------------
+    # Article extraction
+    # ------------------------------------------------------------------
+    async def get_article(self, link, keyword):
+        if not _is_article_url(link):
+            logging.debug("ABC News rejecting non-article URL: %s", link)
+            return
+
+        response_text = await self.fetch(link, headers=self.headers, timeout=30)
+        if not response_text:
+            logging.warning("ABC News no response for %s", link)
+            return
+
+        soup = BeautifulSoup(response_text, "html.parser")
+        node = self._news_article_node(soup)
+
+        title = self._extract_title(soup, node)
+        if not title:
+            return
+
+        publish_date = self._extract_date(soup, node)
+        if not publish_date:
+            return
+
+        if self.start_date and publish_date < self.start_date:
+            return
+
+        content = self._extract_content(soup)
+        if not content:
+            return
+
+        item = {
+            "title": title,
+            "publish_date": publish_date,
+            "author": self._extract_author(soup, node),
+            "content": content,
+            "keyword": keyword,
+            "category": self._extract_category(node, link),
+            "source": self.SOURCE_LABEL,
+            "link": link,
+        }
+        await self.queue_.put(item)
+
+    @staticmethod
+    def _news_article_node(soup):
+        """The JSON-LD NewsArticle node, or None. ABC also emits WebSite/WebPage."""
+        import json
+
+        for script in soup.find_all("script", {"type": "application/ld+json"}):
+            if not script.string:
+                continue
+            try:
+                payload = json.loads(script.string)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            nodes = payload if isinstance(payload, list) else [payload]
+            for entry in nodes:
+                if not isinstance(entry, dict):
+                    continue
+                for candidate in entry.get("@graph") or [entry]:
+                    if not isinstance(candidate, dict):
+                        continue
+                    types = candidate.get("@type") or ""
+                    types = types if isinstance(types, list) else [types]
+                    if any("NewsArticle" in str(t) or "Article" == str(t) for t in types):
+                        return candidate
+        return None
+
+    @staticmethod
+    def _extract_title(soup, node):
+        if node:
+            headline = node.get("headline")
+            if headline:
+                return str(headline).strip()
+        meta = soup.find("meta", {"property": "og:title"})
+        if meta and meta.get("content"):
+            return meta["content"].strip()
+        if soup.h1:
+            return soup.h1.get_text(strip=True)
+        return ""
+
+    def _extract_date(self, soup, node):
+        if node:
+            for key in ("datePublished", "dateCreated", "dateModified"):
+                raw = node.get(key)
+                if raw:
+                    parsed = self.parse_date(str(raw))
+                    if parsed:
+                        return parsed
+        time_el = soup.find("time", attrs={"datetime": True})
+        if time_el:
+            return self.parse_date(time_el["datetime"])
+        return None
+
+    @staticmethod
+    def _extract_author(soup, node):
+        if node:
+            author = node.get("author")
+            candidates = author if isinstance(author, list) else [author]
+            names = []
+            for entry in candidates:
+                if isinstance(entry, dict):
+                    name = (entry.get("name") or "").strip()
+                elif isinstance(entry, str):
+                    name = entry.strip()
+                else:
+                    name = ""
+                if name and name not in names:
+                    names.append(name)
+            if names:
+                return ", ".join(names)
+        meta = soup.find("meta", {"name": "author"})
+        if meta and meta.get("content"):
+            return meta["content"].strip()
+        return "Unknown"
+
+    @staticmethod
+    def _extract_category(node, link):
+        if node:
+            section = node.get("articleSection")
+            if section:
+                if isinstance(section, list):
+                    section = section[0] if section else ""
+                if section:
+                    return str(section).strip()
+        parts = [p for p in urlparse(link).path.split("/") if p]
+        return parts[0] if parts else "news"
+
+    @staticmethod
+    def _extract_content(soup):
+        body = soup.select_one('div[data-testid="prism-article-body"]')
+        if body is None:
+            body = soup.select_one("article")
+        if body is None:
+            return ""
+        for tag in list(body.find_all(["script", "style", "iframe", "noscript", "figure"])):
+            tag.extract()
+        paragraphs = [
+            text
+            for p in body.find_all("p")
+            if len(text := p.get_text(" ", strip=True)) >= 30
+        ]
+        content = " ".join(paragraphs).strip()
+        return content or body.get_text(" ", strip=True)

--- a/src/newswatch/scrapers/basescraper.py
+++ b/src/newswatch/scrapers/basescraper.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 
 import dateparser
 
+from ..timeutils import to_project_naive
 from ..utils import AsyncScraper
 
 
@@ -37,7 +38,9 @@ class BaseScraper(AsyncScraper, ABC):
     def parse_date(self, date_string, **kwargs):
         parsed_date = dateparser.parse(date_string, **kwargs)
         if parsed_date:
-            return parsed_date.replace(tzinfo=None)
+            # convert the offset, don't discard it: a -04:00 and a +07:00
+            # article are 11 hours apart, not the same instant
+            return to_project_naive(parsed_date)
         return None
 
     @abstractmethod

--- a/src/newswatch/scrapers/bbc.py
+++ b/src/newswatch/scrapers/bbc.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 from bs4 import BeautifulSoup
 
+from ..timeutils import to_project_naive
 from .basescraper import BaseScraper
 
 
@@ -49,7 +50,7 @@ class BBCNewsScraper(BaseScraper):
             if self.start_date:
                 first_updated = meta.get("firstUpdated")
                 if first_updated:
-                    article_date = datetime.fromtimestamp(first_updated / 1000, tz=timezone.utc).replace(tzinfo=None)
+                    article_date = to_project_naive(datetime.fromtimestamp(first_updated / 1000, tz=timezone.utc))
                     if article_date < self.start_date:
                         continue
             href = r.get("href", "")
@@ -140,7 +141,7 @@ class BBCNewsScraper(BaseScraper):
 
         publish_date = None
         if publish_ts:
-            publish_date = datetime.fromtimestamp(publish_ts / 1000, tz=timezone.utc).replace(tzinfo=None)
+            publish_date = to_project_naive(datetime.fromtimestamp(publish_ts / 1000, tz=timezone.utc))
         if not publish_date:
             return
 

--- a/src/newswatch/scrapers/conversationid.py
+++ b/src/newswatch/scrapers/conversationid.py
@@ -33,6 +33,7 @@ from urllib.parse import quote, urljoin
 
 from bs4 import BeautifulSoup
 
+from ..timeutils import to_project_naive
 from .basescraper import BaseScraper
 
 
@@ -238,11 +239,8 @@ def _parse_iso(value):
     raw = value.strip()
     if raw.endswith("Z"):
         raw = raw[:-1] + "+00:00"
-    from datetime import datetime, timezone
+    from datetime import datetime
     try:
-        parsed = datetime.fromisoformat(raw)
-        if parsed.tzinfo is not None:
-            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-        return parsed
+        return to_project_naive(datetime.fromisoformat(raw))
     except (ValueError, TypeError):
         return None

--- a/src/newswatch/scrapers/idnfinancials.py
+++ b/src/newswatch/scrapers/idnfinancials.py
@@ -21,6 +21,7 @@ from urllib.parse import quote, urljoin
 
 from bs4 import BeautifulSoup
 
+from ..timeutils import to_project_naive
 from .basescraper import BaseScraper
 
 # Task-local current keyword: each concurrent `fetch_search_results`
@@ -106,10 +107,9 @@ def _parse_iso_datetime(value):
     try:
         # python's fromisoformat handles "+07:00" offsets in 3.11+
         cleaned = value.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(cleaned)
-        if dt.tzinfo is not None:
-            dt = dt.astimezone(tz=None).replace(tzinfo=None)
-        return dt
+        # not astimezone(tz=None): that resolves to the runner machine's zone,
+        # so the same article yielded a different timestamp per host
+        return to_project_naive(datetime.fromisoformat(cleaned))
     except (TypeError, ValueError):
         return None
 

--- a/src/newswatch/scrapers/idxchannel.py
+++ b/src/newswatch/scrapers/idxchannel.py
@@ -26,6 +26,7 @@ from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 
+from ..timeutils import to_project_naive
 from .basescraper import BaseScraper
 
 _SM_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
@@ -85,15 +86,10 @@ def _matches_all_tokens(haystack, tokens):
 
 
 def _to_naive(value):
-    """Strip tz info for the queue payload; dateparser may return aware datetimes."""
+    """Normalize to the reference zone for the queue payload."""
     if value is None:
         return None
-    if value.tzinfo is not None:
-        try:
-            return value.replace(tzinfo=None)
-        except (AttributeError, ValueError):
-            return value
-    return value
+    return to_project_naive(value)
 
 
 def _is_canonical_article(url):

--- a/src/newswatch/scrapers/independen.py
+++ b/src/newswatch/scrapers/independen.py
@@ -31,11 +31,12 @@ Latest is latest-only — homepage page 1.
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
+from ..timeutils import to_project_naive
 from .basescraper import BaseScraper
 
 
@@ -117,9 +118,7 @@ def _parse_iso(value):
         parsed = datetime.fromisoformat(raw)
     except ValueError:
         return None
-    if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-    return parsed
+    return to_project_naive(parsed)
 
 
 class IndependenScraper(BaseScraper):

--- a/src/newswatch/scrapers/nbcnews.py
+++ b/src/newswatch/scrapers/nbcnews.py
@@ -1,0 +1,395 @@
+"""
+NBC News (nbcnews.com) scraper — monthly archive for search, news sitemap for latest.
+
+Verified endpoints (2026-07-27):
+    archive: https://www.nbcnews.com/archive/articles/<year>/<month-name>
+             one page per calendar month, ~1200 anchors under a single
+             .MonthPage container, each anchor's text is the headline;
+             no pagination
+    latest:  https://www.nbcnews.com/sitemap/nbcnews/sitemap-news
+             (urlset, ~53 entries, <news:title> + <news:publication_date>)
+    article: https://www.nbcnews.com/<section>/.../<slug>-rcna<digits>
+
+robots.txt disallows /search and /pages/search/, so keyword search filters the
+monthly archive instead. Unlike the other feed-filtering adapters this gives
+real historical reach -- the archive is addressable by month for years back --
+so the search path walks the months spanned by start_date rather than a single
+recent window.
+
+Two paths are deliberately not used: https://www.nbcnews.com/sitemap.xml is
+blocked (only the paths robots advertises respond), and
+feeds.nbcnews.com/nbcnews/public/news mixes today.com links and a bare
+homepage link, which would put the wrong value in the source field.
+"""
+import logging
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from .basescraper import BaseScraper
+
+_SM_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_NEWS_NS = "http://www.google.com/schemas/sitemap-news/0.9"
+_NSMAP = {"sm": _SM_NS, "news": _NEWS_NS}
+
+_BASE_URL = "https://www.nbcnews.com"
+_LATEST_SITEMAP_URL = f"{_BASE_URL}/sitemap/nbcnews/sitemap-news"
+
+_ALLOWED_HOSTS = ("nbcnews.com", "www.nbcnews.com")
+
+# Canonical article slugs end in -rcna<digits>.
+_ARTICLE_ID_RE = re.compile(r"-rcna\d+/?$", re.IGNORECASE)
+
+# Live blogs re-publish under one URL with a stale datePublished, and
+# video/photo surfaces carry no story text.
+_NON_ARTICLE_RE = re.compile(r"/(?:live-blog|video|videos|photos)(?:/|$)", re.IGNORECASE)
+
+_MONTH_NAMES = (
+    "january", "february", "march", "april", "may", "june",
+    "july", "august", "september", "october", "november", "december",
+)
+
+
+def _normalize(text):
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _keyword_tokens(keyword):
+    return [tok for tok in re.split(r"\W+", (keyword or "").lower()) if len(tok) > 1]
+
+
+def _matches_all_tokens(haystack, tokens):
+    if not tokens:
+        return True
+    if not haystack:
+        return False
+    return all(re.search(rf"\b{re.escape(tok)}\b", haystack) for tok in tokens)
+
+
+def _is_article_url(url):
+    if not url:
+        return False
+    parsed = urlparse(url)
+    if (parsed.netloc or "").lower() not in _ALLOWED_HOSTS:
+        return False
+    if _NON_ARTICLE_RE.search(parsed.path):
+        return False
+    return bool(_ARTICLE_ID_RE.search(parsed.path))
+
+
+def _months_descending(start, end):
+    """(year, month) pairs from `end` back to `start`, newest first."""
+    months = []
+    year, month = end.year, end.month
+    while (year, month) >= (start.year, start.month):
+        months.append((year, month))
+        month -= 1
+        if month == 0:
+            year, month = year - 1, 12
+    return months
+
+
+class NBCNewsScraper(BaseScraper):
+    """NBC News adapter: monthly archive pages for search, news sitemap for latest."""
+
+    BASE_URL = _BASE_URL
+    LATEST_SITEMAP_URL = _LATEST_SITEMAP_URL
+    SOURCE_LABEL = "nbcnews.com"
+    MAX_ARTICLES_PER_QUERY = 25
+    # Archive pages are ~3 MB each; bound how far one run will walk back.
+    MAX_MONTHS = 12
+
+    def __init__(self, keywords, concurrency=5, start_date=None, queue_=None):
+        super().__init__(keywords, concurrency, queue_)
+        self.base_url = self.BASE_URL
+        self.start_date = start_date
+        self._current_keyword = ""
+        self.headers = {"Accept-Language": "en-US,en;q=0.9"}
+
+    # ------------------------------------------------------------------
+    # Month planning
+    # ------------------------------------------------------------------
+    def _months(self):
+        """Months to walk, newest first. Without start_date, the current month only."""
+        now = datetime.now()
+        start = self.start_date or now
+        return _months_descending(start, now)[: self.MAX_MONTHS]
+
+    def archive_url(self, year, month):
+        return f"{self.BASE_URL}/archive/articles/{year}/{_MONTH_NAMES[month - 1]}"
+
+    # ------------------------------------------------------------------
+    # Archive parsing
+    # ------------------------------------------------------------------
+    @staticmethod
+    def parse_archive_entries(response_text):
+        """Return [(url, headline)] from a monthly archive page."""
+        if not response_text:
+            return []
+        soup = BeautifulSoup(response_text, "html.parser")
+        entries = []
+        seen = set()
+        for anchor in soup.select(".MonthPage a[href]"):
+            href = (anchor.get("href") or "").strip()
+            if href.startswith("/"):
+                href = f"{_BASE_URL}{href}"
+            if not _is_article_url(href) or href in seen:
+                continue
+            entries.append((href, anchor.get_text(" ", strip=True)))
+            seen.add(href)
+        return entries
+
+    def _select(self, entries, tokens):
+        links = []
+        for url, headline in entries:
+            if tokens and not _matches_all_tokens(
+                _normalize(f"{headline} {url}"), tokens
+            ):
+                continue
+            links.append(url)
+            if len(links) >= self.MAX_ARTICLES_PER_QUERY:
+                break
+        return links or None
+
+    # ------------------------------------------------------------------
+    # Search path: one archive month per page
+    # ------------------------------------------------------------------
+    async def build_search_url(self, keyword, page):
+        self._current_keyword = keyword or ""
+        months = self._months()
+        if page < 1 or page > len(months):
+            return None
+        year, month = months[page - 1]
+        return await self.fetch(
+            self.archive_url(year, month), headers=self.headers, timeout=45
+        )
+
+    def parse_article_links(self, response_text):
+        if not response_text:
+            return None
+        entries = self.parse_archive_entries(response_text)
+        return self._select(entries, _keyword_tokens(self._current_keyword))
+
+    async def fetch_search_results(self, keyword):
+        """Walk every planned month.
+
+        BaseScraper's page loop stops at the first page that yields no links,
+        which here would mean one keyword-less month hides every older month
+        behind it. Months are independent, so iterate them all and only stop on
+        the per-keyword article cap.
+        """
+        self._current_keyword = keyword or ""
+        tokens = _keyword_tokens(keyword)
+        collected = 0
+        found_any = False
+
+        for year, month in self._months():
+            if not self.continue_scraping:
+                break
+            response_text = await self.fetch(
+                self.archive_url(year, month), headers=self.headers, timeout=45
+            )
+            if not response_text:
+                continue
+
+            links = self._select(self.parse_archive_entries(response_text), tokens)
+            if not links:
+                continue
+
+            found_any = True
+            remaining = self.MAX_ARTICLES_PER_QUERY - collected
+            links = links[:remaining]
+            collected += len(links)
+
+            if not await self.process_page(links, keyword):
+                break
+            if collected >= self.MAX_ARTICLES_PER_QUERY:
+                break
+
+        if not found_any:
+            logging.info(
+                f"No news found on {self.base_url} for keyword: '{keyword}'"
+            )
+
+    # ------------------------------------------------------------------
+    # Latest path: news sitemap
+    # ------------------------------------------------------------------
+    async def build_latest_url(self, page):
+        if page != 1:
+            return None
+        return await self.fetch(
+            self.LATEST_SITEMAP_URL, headers=self.headers, timeout=30
+        )
+
+    @staticmethod
+    def parse_sitemap_entries(response_text):
+        """Return [(loc, title)] from the news sitemap urlset."""
+        if not response_text:
+            return []
+        head = response_text.lstrip()[:64].lower()
+        if not head.startswith("<?xml") and "<urlset" not in head:
+            return []
+        try:
+            root = ET.fromstring(response_text)
+        except ET.ParseError as e:
+            logging.error("NBC News sitemap parse error: %s", e)
+            return []
+        if root.tag != f"{{{_SM_NS}}}urlset":
+            return []
+
+        entries = []
+        for url in root.findall("sm:url", _NSMAP):
+            loc = (url.findtext("sm:loc", "", _NSMAP) or "").strip()
+            if not loc or not _is_article_url(loc):
+                continue
+            title = ""
+            news = url.find("news:news", _NSMAP)
+            if news is not None:
+                title = (news.findtext("news:title", "", _NSMAP) or "").strip()
+            entries.append((loc, title))
+        return entries
+
+    def parse_latest_article_links(self, response_text):
+        if not response_text:
+            return None
+        return self._select(self.parse_sitemap_entries(response_text), [])
+
+    # ------------------------------------------------------------------
+    # Article extraction
+    # ------------------------------------------------------------------
+    async def get_article(self, link, keyword):
+        if not _is_article_url(link):
+            logging.debug("NBC News rejecting non-article URL: %s", link)
+            return
+
+        response_text = await self.fetch(link, headers=self.headers, timeout=30)
+        if not response_text:
+            logging.warning("NBC News no response for %s", link)
+            return
+
+        soup = BeautifulSoup(response_text, "html.parser")
+        node = self._news_article_node(soup)
+
+        title = self._extract_title(soup, node)
+        if not title:
+            return
+
+        publish_date = self._extract_date(soup, node)
+        if not publish_date:
+            return
+
+        if self.start_date and publish_date < self.start_date:
+            return
+
+        content = self._extract_content(soup)
+        if not content:
+            return
+
+        item = {
+            "title": title,
+            "publish_date": publish_date,
+            "author": self._extract_author(soup, node),
+            "content": content,
+            "keyword": keyword,
+            "category": self._extract_category(node, link),
+            "source": self.SOURCE_LABEL,
+            "link": link,
+        }
+        await self.queue_.put(item)
+
+    @staticmethod
+    def _news_article_node(soup):
+        import json
+
+        for script in soup.find_all("script", {"type": "application/ld+json"}):
+            if not script.string:
+                continue
+            try:
+                payload = json.loads(script.string)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            nodes = payload if isinstance(payload, list) else [payload]
+            for entry in nodes:
+                if not isinstance(entry, dict):
+                    continue
+                for candidate in entry.get("@graph") or [entry]:
+                    if isinstance(candidate, dict) and "Article" in str(
+                        candidate.get("@type")
+                    ):
+                        return candidate
+        return None
+
+    @staticmethod
+    def _extract_title(soup, node):
+        if node and node.get("headline"):
+            return str(node["headline"]).strip()
+        meta = soup.find("meta", {"property": "og:title"})
+        if meta and meta.get("content"):
+            return meta["content"].strip()
+        if soup.h1:
+            return soup.h1.get_text(strip=True)
+        return ""
+
+    def _extract_date(self, soup, node):
+        if node:
+            for key in ("datePublished", "dateCreated", "dateModified"):
+                if node.get(key):
+                    parsed = self.parse_date(str(node[key]))
+                    if parsed:
+                        return parsed
+        time_el = soup.find("time", attrs={"datetime": True})
+        if time_el:
+            return self.parse_date(time_el["datetime"])
+        return None
+
+    @staticmethod
+    def _extract_author(soup, node):
+        if node:
+            author = node.get("author")
+            names = []
+            for entry in author if isinstance(author, list) else [author]:
+                if isinstance(entry, dict):
+                    name = (entry.get("name") or "").strip()
+                elif isinstance(entry, str):
+                    name = entry.strip()
+                else:
+                    name = ""
+                if name and name not in names:
+                    names.append(name)
+            if names:
+                return ", ".join(names)
+        meta = soup.find("meta", {"name": "author"})
+        if meta and meta.get("content"):
+            return meta["content"].strip()
+        return "Unknown"
+
+    @staticmethod
+    def _extract_category(node, link):
+        if node and node.get("articleSection"):
+            section = node["articleSection"]
+            if isinstance(section, list):
+                section = section[0] if section else ""
+            if section:
+                return str(section).strip()
+        parts = [p for p in urlparse(link).path.split("/") if p]
+        return parts[0] if parts else "news"
+
+    @staticmethod
+    def _extract_content(soup):
+        body = soup.select_one("div.article-body__content") or soup.select_one("article")
+        if body is None:
+            return ""
+        for tag in list(
+            body.find_all(["script", "style", "iframe", "noscript", "figure", "aside"])
+        ):
+            tag.extract()
+        paragraphs = [
+            text
+            for p in body.find_all("p")
+            if len(text := p.get_text(" ", strip=True)) >= 30
+        ]
+        content = " ".join(paragraphs).strip()
+        return content or body.get_text(" ", strip=True)

--- a/src/newswatch/scrapers/nbcnews.py
+++ b/src/newswatch/scrapers/nbcnews.py
@@ -116,7 +116,21 @@ class NBCNewsScraper(BaseScraper):
         """Months to walk, newest first. Without start_date, the current month only."""
         now = datetime.now()
         start = self.start_date or now
-        return _months_descending(start, now)[: self.MAX_MONTHS]
+        planned = _months_descending(start, now)
+        if len(planned) > self.MAX_MONTHS:
+            kept = planned[: self.MAX_MONTHS]
+            oldest_kept = kept[-1]
+            logging.warning(
+                "NBC News: start_date spans %d months but at most %d are fetched per "
+                "run; not reading anything before %04d-%02d. Narrow --start_date or "
+                "run in slices to cover the rest.",
+                len(planned),
+                self.MAX_MONTHS,
+                oldest_kept[0],
+                oldest_kept[1],
+            )
+            return kept
+        return planned
 
     def archive_url(self, year, month):
         return f"{self.BASE_URL}/archive/articles/{year}/{_MONTH_NAMES[month - 1]}"
@@ -207,6 +221,12 @@ class NBCNewsScraper(BaseScraper):
             if not await self.process_page(links, keyword):
                 break
             if collected >= self.MAX_ARTICLES_PER_QUERY:
+                logging.warning(
+                    "NBC News: hit the %d-article cap for keyword '%s'; older "
+                    "matches in the remaining months were not fetched.",
+                    self.MAX_ARTICLES_PER_QUERY,
+                    keyword,
+                )
                 break
 
         if not found_any:

--- a/src/newswatch/timeutils.py
+++ b/src/newswatch/timeutils.py
@@ -1,0 +1,41 @@
+"""One clock for publish timestamps.
+
+Publishers report in whatever zone they use: ``+07:00`` from Indonesian
+sources, ``-04:00`` from US ones, ``Z`` from wire feeds. Queue payloads,
+``--start_date`` and ``--time_range`` are all naive datetimes, so every source
+has to agree on what a naive value *means* -- otherwise a single output file
+carries two clocks and the date filters compare across them.
+
+That reference zone is ``Asia/Jakarta`` (override: ``NEWSWATCH_TIMEZONE``).
+It is the zone the large majority of registered sources already publish in, so
+converting into it leaves their timestamps unchanged while giving
+offset-bearing sources a correct place to land.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from . import config
+
+
+def project_timezone():
+    """The reference zone as a ZoneInfo."""
+    return ZoneInfo(config.get_timezone())
+
+
+def to_project_naive(value, assume_tz=None):
+    """Convert to the reference zone, then drop tzinfo.
+
+    Aware input is converted -- the offset is honored, not discarded. Naive
+    input is returned unchanged unless ``assume_tz`` states which zone it was
+    already in, so the common case is a no-op rather than a silent
+    reinterpretation. Non-datetime input passes through so callers can apply
+    this before their own type checks.
+    """
+    if not isinstance(value, datetime):
+        return value
+    if value.tzinfo is None:
+        if assume_tz is None:
+            return value
+        value = value.replace(tzinfo=assume_tz)
+    return value.astimezone(project_timezone()).replace(tzinfo=None)

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -63,7 +63,9 @@ import pytest
 from bs4 import BeautifulSoup
 
 from newswatch.timeutils import to_project_naive
+from newswatch.scrapers.abcnews import ABCNewsScraper
 from newswatch.scrapers.alinea import AlineaScraper
+from newswatch.scrapers.nbcnews import NBCNewsScraper
 from newswatch.scrapers.betahita import BetahitaScraper
 from newswatch.scrapers.conversationid import ConversationIDScraper
 from newswatch.scrapers.ddtcnews import DDTCNewsScraper
@@ -126,6 +128,15 @@ def _attach_fetch(scraper: Any, responses: dict[str, str]) -> _FetchStub:
     stub = _FetchStub(responses)
     scraper.fetch = stub
     return stub
+
+
+def _record_links(sink: list) -> Any:
+    """Stand-in for get_article that records the links it was handed."""
+
+    async def _get_article(link, keyword):
+        sink.append(link)
+
+    return _get_article
 
 
 # ── 1. Kumparan: latest mode consumes active RSS XML ─────────────────────
@@ -3919,3 +3930,330 @@ class TestVOIDiscovery:
         assert await scraper.build_search_url("pasar modal", 2) == _voi_index_html()
         assert stub.calls[0][0] == f"{self.BASE}/en/artikel/cari?q=pasar+modal&page=2"
         assert scraper.parse_article_links("<p>Found 0 articles</p>") is None
+
+
+# ── ABC News: news-sitemap keyword filtering + article extraction ─────────
+
+
+def _abcnews_feed_xml(entries=None):
+    entries = entries or [
+        (
+            "https://abcnews.com/Politics/wireStory/police-reform-bill-advances-135112211",
+            "Police reform bill advances in the Senate",
+            "2026-07-27T12:29:49+00:00",
+        ),
+        (
+            "https://abcnews.com/Sports/story/marathon-record-broken-135000000",
+            "Marathon record broken in Boston",
+            "2026-07-26T10:00:00+00:00",
+        ),
+        (
+            "https://abcnews.com/US/video/storm-footage-134900000",
+            "Storm footage from the coast",
+            "2026-07-25T10:00:00+00:00",
+        ),
+        (
+            "https://othersite.example.com/Politics/story/off-domain-1",
+            "Off domain story",
+            "2026-07-25T10:00:00+00:00",
+        ),
+    ]
+    blocks = "".join(
+        f"<url><loc>{loc}</loc><lastmod>{date}</lastmod>"
+        f"<news:news><news:publication><news:name>ABC News</news:name>"
+        f"<news:language>en</news:language></news:publication>"
+        f"<news:publication_date>{date}</news:publication_date>"
+        f"<news:title><![CDATA[{title}]]></news:title></news:news></url>"
+        for loc, title, date in entries
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" '
+        'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">'
+        f"{blocks}</urlset>"
+    )
+
+
+def _abcnews_article_html():
+    return """<!doctype html><html><head>
+        <meta property="og:title" content="og fallback title">
+        <script type="application/ld+json">{"@type":"WebSite","name":"ABC"}</script>
+        <script type="application/ld+json">{"@type":"NewsArticle",
+            "headline":"Police reform bill advances in the Senate",
+            "datePublished":"2026-07-27T10:47:18.000Z",
+            "articleSection":"Politics",
+            "author":[{"@type":"Person","name":"JANE DOE Associated Press"}]}</script>
+        </head><body>
+        <div data-testid="prism-article-body">
+            <p>Short.</p>
+            <p>The bill cleared its final procedural hurdle on Monday evening after a
+               lengthy floor debate that stretched past midnight.</p>
+            <script>tracking()</script>
+            <p>Supporters said the measure would standardize reporting requirements
+               across several hundred local departments nationwide.</p>
+        </div></body></html>"""
+
+
+class TestABCNewsFocus:
+    BASE = "https://abcnews.com"
+
+    def _scraper(self, **kwargs):
+        return ABCNewsScraper(keywords="police", queue_=asyncio.Queue(), **kwargs)
+
+    def test_feed_parser_keeps_articles_and_drops_video_and_off_domain(self):
+        s = self._scraper()
+        entries = s._parse_feed(_abcnews_feed_xml())
+        locs = [loc for loc, _t, _d in entries]
+        assert locs == [
+            f"{self.BASE}/Politics/wireStory/police-reform-bill-advances-135112211",
+            f"{self.BASE}/Sports/story/marathon-record-broken-135000000",
+        ]
+        # news:publication_date is parsed, so the date cutoff needs no article fetch.
+        assert entries[0][2] == to_project_naive(
+            datetime(2026, 7, 27, 12, 29, 49, tzinfo=timezone.utc)
+        )
+
+    def test_feed_parser_rejects_non_xml_and_empty(self):
+        s = self._scraper()
+        assert s._parse_feed("") == []
+        assert s._parse_feed("<html><body>not a sitemap</body></html>") == []
+
+    def test_search_applies_every_token_keyword_gate(self):
+        s = self._scraper()
+        s._current_keyword = "police reform"
+        assert s.parse_article_links(_abcnews_feed_xml()) == [
+            f"{self.BASE}/Politics/wireStory/police-reform-bill-advances-135112211"
+        ]
+        s._current_keyword = "marathon nonexistent"
+        assert s.parse_article_links(_abcnews_feed_xml()) is None
+
+    def test_latest_skips_the_keyword_gate(self):
+        s = self._scraper()
+        s._current_keyword = "police"
+        assert len(s.parse_latest_article_links(_abcnews_feed_xml())) == 2
+
+    def test_start_date_cutoff_applies_before_any_article_fetch(self):
+        s = self._scraper(start_date=datetime(2026, 7, 27))
+        s._current_keyword = ""
+        links = s.parse_latest_article_links(_abcnews_feed_xml())
+        assert links == [
+            f"{self.BASE}/Politics/wireStory/police-reform-bill-advances-135112211"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_search_url_returns_feed_on_page_one_only(self):
+        s = self._scraper()
+        stub = _attach_fetch(s, {f"{self.BASE}/xmlLatestStories": _abcnews_feed_xml()})
+        assert await s.build_search_url("police", 1)
+        assert stub.calls[0][0] == f"{self.BASE}/xmlLatestStories"
+        assert await s.build_search_url("police", 2) is None
+
+    @pytest.mark.asyncio
+    async def test_extracts_full_queue_item_from_json_ld(self):
+        link = f"{self.BASE}/Politics/wireStory/police-reform-bill-advances-135112211"
+        s = self._scraper()
+        _attach_fetch(s, {link: _abcnews_article_html()})
+        await s.get_article(link, "police")
+
+        item = s.queue_.get_nowait()
+        # JSON-LD headline wins over og:title, and the WebSite node is skipped.
+        assert item["title"] == "Police reform bill advances in the Senate"
+        assert item["publish_date"] == to_project_naive(
+            datetime(2026, 7, 27, 10, 47, 18, tzinfo=timezone.utc)
+        )
+        assert item["publish_date"].tzinfo is None
+        assert item["author"] == "JANE DOE Associated Press"
+        assert item["category"] == "Politics"
+        assert item["source"] == "abcnews.com"
+        assert item["link"] == link
+        # Sub-30-character paragraphs and scripts are dropped from the body.
+        assert "Short." not in item["content"]
+        assert "tracking()" not in item["content"]
+        assert "final procedural hurdle" in item["content"]
+
+    @pytest.mark.asyncio
+    async def test_article_older_than_start_date_is_not_queued(self):
+        link = f"{self.BASE}/Politics/wireStory/police-reform-bill-advances-135112211"
+        s = self._scraper(start_date=datetime(2026, 8, 1))
+        _attach_fetch(s, {link: _abcnews_article_html()})
+        await s.get_article(link, "police")
+        assert s.queue_.empty()
+
+    @pytest.mark.asyncio
+    async def test_non_article_url_is_never_fetched(self):
+        s = self._scraper()
+        stub = _attach_fetch(s, {})
+        await s.get_article(f"{self.BASE}/US/video/storm-footage-134900000", "police")
+        await s.get_article("https://othersite.example.com/a/b", "police")
+        assert stub.calls == []
+        assert s.queue_.empty()
+
+
+# ── NBC News: monthly archive walk + news sitemap latest ──────────────────
+
+
+def _nbcnews_archive_html(items=None):
+    items = items or [
+        (
+            "https://www.nbcnews.com/news/us-news/police-reform-vote-rcna589267",
+            "Police reform vote clears committee",
+        ),
+        (
+            "https://www.nbcnews.com/world/europe/wildfire-evacuations-rcna589111",
+            "Wildfire evacuations widen in southern Europe",
+        ),
+        (
+            "https://www.nbcnews.com/politics/live-blog/live-updates-rcna500000",
+            "Live updates on the hearing",
+        ),
+        (
+            "https://www.nbcnews.com/news/us-news/no-id-suffix-here",
+            "Story without an rcna id",
+        ),
+    ]
+    links = "".join(f'<a href="{url}">{text}</a>' for url, text in items)
+    return f'<!doctype html><html><body><div class="MonthPage">{links}</div></body></html>'
+
+
+def _nbcnews_sitemap_xml():
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" '
+        'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">'
+        "<url><loc>https://www.nbcnews.com/news/us-news/police-reform-vote-rcna589267</loc>"
+        "<news:news><news:publication_date>2026-07-27T12:43:21.335Z</news:publication_date>"
+        "<news:title>Police reform vote clears committee</news:title></news:news></url>"
+        "<url><loc>https://www.nbcnews.com/politics/live-blog/live-updates-rcna500000</loc>"
+        "<news:news><news:title>Live updates</news:title></news:news></url>"
+        "</urlset>"
+    )
+
+
+def _nbcnews_article_html():
+    return """<!doctype html><html><head>
+        <script type="application/ld+json">[{"@type":"NewsArticle",
+            "headline":"Police reform vote clears committee",
+            "datePublished":"2026-07-27T11:12:02.787Z",
+            "articleSection":"news",
+            "author":[{"@type":"Person","name":"Kayla Hayempour"},
+                      {"@type":"Person","name":"Mark Ho"}]}]</script>
+        </head><body>
+        <div class="article-body__content">
+            <p>Tiny.</p>
+            <p>The committee advanced the measure on a narrow vote after two hours of
+               debate over the reporting requirements it would impose.</p>
+            <aside><p>Sign up for our newsletter to get the morning rundown daily.</p></aside>
+        </div></body></html>"""
+
+
+class TestNBCNewsFocus:
+    BASE = "https://www.nbcnews.com"
+
+    def _scraper(self, **kwargs):
+        return NBCNewsScraper(keywords="police", queue_=asyncio.Queue(), **kwargs)
+
+    def test_archive_parser_requires_rcna_id_and_drops_live_blogs(self):
+        s = self._scraper()
+        entries = s.parse_archive_entries(_nbcnews_archive_html())
+        assert [url for url, _t in entries] == [
+            f"{self.BASE}/news/us-news/police-reform-vote-rcna589267",
+            f"{self.BASE}/world/europe/wildfire-evacuations-rcna589111",
+        ]
+
+    def test_archive_parser_rejects_empty(self):
+        assert self._scraper().parse_archive_entries("") == []
+
+    def test_archive_url_uses_lowercase_month_names(self):
+        s = self._scraper()
+        assert s.archive_url(2026, 7) == f"{self.BASE}/archive/articles/2026/july"
+        assert s.archive_url(2024, 3) == f"{self.BASE}/archive/articles/2024/march"
+
+    def test_months_walk_backwards_from_now_and_are_capped(self):
+        s = self._scraper(start_date=datetime(2026, 4, 1))
+        months = s._months()
+        assert months[0] > months[-1]
+        assert len(months) <= s.MAX_MONTHS
+        # Without start_date only the current month is planned.
+        assert len(self._scraper()._months()) == 1
+
+    def test_months_respect_the_max_months_cap(self):
+        s = self._scraper(start_date=datetime(2000, 1, 1))
+        assert len(s._months()) == s.MAX_MONTHS
+
+    def test_search_applies_every_token_keyword_gate(self):
+        s = self._scraper()
+        s._current_keyword = "police reform"
+        assert s.parse_article_links(_nbcnews_archive_html()) == [
+            f"{self.BASE}/news/us-news/police-reform-vote-rcna589267"
+        ]
+        s._current_keyword = "police wildfire"
+        assert s.parse_article_links(_nbcnews_archive_html()) is None
+
+    def test_latest_sitemap_parser_filters_to_articles(self):
+        s = self._scraper()
+        assert s.parse_latest_article_links(_nbcnews_sitemap_xml()) == [
+            f"{self.BASE}/news/us-news/police-reform-vote-rcna589267"
+        ]
+        assert s.parse_latest_article_links("") is None
+        assert s.parse_latest_article_links("<html>not xml</html>") is None
+
+    @pytest.mark.asyncio
+    async def test_latest_url_is_the_news_sitemap_on_page_one_only(self):
+        s = self._scraper()
+        stub = _attach_fetch(s, {f"{self.BASE}/sitemap/nbcnews/sitemap-news": "<urlset/>"})
+        await s.build_latest_url(1)
+        assert stub.calls[0][0] == f"{self.BASE}/sitemap/nbcnews/sitemap-news"
+        assert await s.build_latest_url(2) is None
+
+    @pytest.mark.asyncio
+    async def test_search_keeps_walking_past_a_month_with_no_matches(self):
+        """A keyword-less month must not hide every older month behind it."""
+        s = self._scraper(start_date=datetime(2026, 5, 1))
+        empty_month = _nbcnews_archive_html(
+            [("https://www.nbcnews.com/news/other/unrelated-rcna1", "Unrelated story")]
+        )
+        responses = {
+            s.archive_url(year, month): (
+                _nbcnews_archive_html() if (year, month) == (2026, 5) else empty_month
+            )
+            for year, month in s._months()
+        }
+        _attach_fetch(s, responses)
+        collected: list = []
+        s.get_article = _record_links(collected)
+
+        await s.fetch_search_results("police reform")
+
+        # Every planned month was requested, and the match in the oldest one
+        # still came through.
+        assert f"{self.BASE}/news/us-news/police-reform-vote-rcna589267" in collected
+
+    @pytest.mark.asyncio
+    async def test_extracts_full_queue_item_from_json_ld(self):
+        link = f"{self.BASE}/news/us-news/police-reform-vote-rcna589267"
+        s = self._scraper()
+        _attach_fetch(s, {link: _nbcnews_article_html()})
+        await s.get_article(link, "police")
+
+        item = s.queue_.get_nowait()
+        assert item["title"] == "Police reform vote clears committee"
+        assert item["publish_date"] == to_project_naive(
+            datetime(2026, 7, 27, 11, 12, 2, 787000, tzinfo=timezone.utc)
+        )
+        assert item["publish_date"].tzinfo is None
+        assert item["author"] == "Kayla Hayempour, Mark Ho"
+        assert item["category"] == "news"
+        assert item["source"] == "nbcnews.com"
+        # aside/newsletter chrome and sub-30-char paragraphs are stripped.
+        assert "Tiny." not in item["content"]
+        assert "newsletter" not in item["content"]
+        assert "narrow vote" in item["content"]
+
+    @pytest.mark.asyncio
+    async def test_non_article_url_is_never_fetched(self):
+        s = self._scraper()
+        stub = _attach_fetch(s, {})
+        await s.get_article(f"{self.BASE}/politics/live-blog/live-updates-rcna1", "police")
+        await s.get_article(f"{self.BASE}/news/us-news/no-id-suffix", "police")
+        assert stub.calls == []
+        assert s.queue_.empty()

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import warnings
 from datetime import datetime, timezone
 from typing import Any
@@ -4179,6 +4180,36 @@ class TestNBCNewsFocus:
     def test_months_respect_the_max_months_cap(self):
         s = self._scraper(start_date=datetime(2000, 1, 1))
         assert len(s._months()) == s.MAX_MONTHS
+
+    def test_month_cap_is_announced_not_silent(self, caplog):
+        """A bound that drops requested coverage has to say so."""
+        s = self._scraper(start_date=datetime(2000, 1, 1))
+        with caplog.at_level(logging.WARNING):
+            s._months()
+        assert "at most" in caplog.text
+        assert "not reading anything before" in caplog.text
+
+    def test_month_cap_stays_quiet_when_it_does_not_bind(self, caplog):
+        s = self._scraper(start_date=datetime.now())
+        with caplog.at_level(logging.WARNING):
+            s._months()
+        assert caplog.text == ""
+
+    @pytest.mark.asyncio
+    async def test_article_cap_is_announced_when_it_binds(self, caplog):
+        s = self._scraper(start_date=datetime(2026, 5, 1))
+        s.MAX_ARTICLES_PER_QUERY = 1
+        responses = {
+            s.archive_url(year, month): _nbcnews_archive_html()
+            for year, month in s._months()
+        }
+        _attach_fetch(s, responses)
+        s.get_article = _record_links([])
+
+        with caplog.at_level(logging.WARNING):
+            await s.fetch_search_results("police reform")
+
+        assert "article cap" in caplog.text
 
     def test_search_applies_every_token_keyword_gate(self):
         s = self._scraper()

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -55,13 +55,14 @@ from __future__ import annotations
 import asyncio
 import json
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote
 
 import pytest
 from bs4 import BeautifulSoup
 
+from newswatch.timeutils import to_project_naive
 from newswatch.scrapers.alinea import AlineaScraper
 from newswatch.scrapers.betahita import BetahitaScraper
 from newswatch.scrapers.conversationid import ConversationIDScraper
@@ -2834,7 +2835,11 @@ class TestConversationIDFocus:
 
         item = s.queue_.get_nowait()
         assert item["title"] == "Conversation ID test headline"
-        assert item["publish_date"] == datetime(2026, 7, 12, 10, 0, 0)
+        # Fixture date is UTC; the queue carries it converted to the reference
+        # zone, not truncated to it.
+        assert item["publish_date"] == to_project_naive(
+            datetime(2026, 7, 12, 10, 0, 0, tzinfo=timezone.utc)
+        )
         assert item["publish_date"].tzinfo is None
         # Multiple authors joined with comma, preserving insertion order.
         assert item["author"] == "Author One, Author Two"
@@ -2857,7 +2862,9 @@ class TestConversationIDFocus:
         await s.get_article(link, "indonesia")
 
         item = s.queue_.get_nowait()
-        assert item["publish_date"] == datetime(2026, 7, 12, 12, 0, 0)
+        assert item["publish_date"] == to_project_naive(
+            datetime(2026, 7, 12, 12, 0, 0, tzinfo=timezone.utc)
+        )
         assert item["publish_date"].tzinfo is None
 
 class TestKaltimPostFocus:
@@ -3162,7 +3169,9 @@ class TestIndependenFocus:
         item = s.queue_.get_nowait()
         # og:title suffix "- Independen.id" must be stripped.
         assert item["title"] == "Independen test headline"
-        assert item["publish_date"] == datetime(2026, 7, 12, 3, 0, 0)
+        assert item["publish_date"] == to_project_naive(
+            datetime(2026, 7, 12, 3, 0, 0, tzinfo=timezone.utc)
+        )
         assert item["publish_date"].tzinfo is None
         assert item["author"] == "Independen Reporter"
         assert item["category"] == "Investigasi"

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,0 +1,208 @@
+"""Contracts for the single-clock convention.
+
+Every source's publish_date has to land on one clock. Before this, an offset
+was discarded rather than converted, so a -04:00 article and a +07:00 article
+published 11 hours apart got identical timestamps -- and the writers' range
+filter compared aware against naive and died. These pin both halves.
+"""
+
+import asyncio
+import csv
+import json
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from newswatch.main import _in_time_range, _parse_time_range, write_csv, write_json, write_jsonl, write_xlsx
+from newswatch.scrapers.basescraper import BaseScraper
+from newswatch.timeutils import project_timezone, to_project_naive
+
+
+class _Dummy(BaseScraper):
+    async def build_search_url(self, keyword, page):
+        return None
+
+    def parse_article_links(self, response_text):
+        return []
+
+    async def get_article(self, link, keyword):
+        pass
+
+
+# ── to_project_naive ─────────────────────────────────────────────────────────
+
+
+def test_aware_input_is_converted_not_truncated():
+    utc_noon = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+    result = to_project_naive(utc_noon)
+    expected = utc_noon.astimezone(project_timezone()).replace(tzinfo=None)
+    assert result == expected
+    assert result.tzinfo is None
+    # Asia/Jakarta is UTC+7, so truncation (12:00) and conversion differ.
+    assert result != utc_noon.replace(tzinfo=None)
+
+
+def test_naive_input_passes_through_unchanged():
+    naive = datetime(2026, 7, 27, 8, 0)
+    assert to_project_naive(naive) == naive
+
+
+def test_assume_tz_reinterprets_naive_input():
+    naive = datetime(2026, 7, 27, 8, 0)
+    result = to_project_naive(naive, assume_tz=ZoneInfo("America/New_York"))
+    assert result != naive
+    assert result == naive.replace(tzinfo=ZoneInfo("America/New_York")).astimezone(
+        project_timezone()
+    ).replace(tzinfo=None)
+
+
+@pytest.mark.parametrize("value", [None, "not a datetime", 42])
+def test_non_datetime_passes_through(value):
+    assert to_project_naive(value) is value
+
+
+def test_same_instant_in_different_zones_collapses_to_one_value():
+    """The core guarantee: identical instants, different offsets, one result."""
+    et = datetime(2026, 7, 27, 8, 0, tzinfo=timezone(timedelta(hours=-4)))
+    wib = datetime(2026, 7, 27, 19, 0, tzinfo=timezone(timedelta(hours=7)))
+    assert et == wib  # same instant
+    assert to_project_naive(et) == to_project_naive(wib)
+
+
+def test_different_instants_sharing_a_wall_clock_stay_distinct():
+    """The bug this fixes: these used to both become 08:00."""
+    et = datetime(2026, 7, 27, 8, 0, tzinfo=timezone(timedelta(hours=-4)))
+    wib = datetime(2026, 7, 27, 8, 0, tzinfo=timezone(timedelta(hours=7)))
+    assert to_project_naive(et) != to_project_naive(wib)
+
+
+# ── BaseScraper.parse_date ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "date_string",
+    [
+        "2026-07-27T08:00:00-04:00",
+        "2026-07-27T19:00:00+07:00",
+        "2026-07-27T12:00:00Z",
+    ],
+)
+def test_parse_date_maps_equivalent_instants_to_one_value(date_string):
+    """All three strings are the same instant, so all three must agree."""
+    scraper = _Dummy("ihsg")
+    reference = to_project_naive(datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc))
+    assert scraper.parse_date(date_string) == reference
+
+
+def test_parse_date_leaves_offsetless_input_on_its_wall_clock():
+    """Indonesian sources publish without an offset; their output must not move."""
+    scraper = _Dummy("ihsg")
+    parsed = scraper.parse_date("2026-07-27 08:00:00")
+    assert parsed == datetime(2026, 7, 27, 8, 0)
+    assert parsed.tzinfo is None
+
+
+def test_parse_date_returns_none_for_garbage():
+    assert _Dummy("ihsg").parse_date("not a date at all") is None
+
+
+# ── _in_time_range ──────────────────────────────────────────────────────────
+
+
+def test_in_time_range_accepts_offset_bearing_string():
+    """Comparing an aware datetime against naive bounds used to raise TypeError."""
+    start, end = _parse_time_range("2026-07-27/2026-07-27")
+    # 08:00-04:00 is 19:00 in Asia/Jakarta, inside the 27th.
+    assert _in_time_range("2026-07-27T08:00:00-04:00", start, end) is True
+
+
+def test_in_time_range_excludes_out_of_range_offset_string():
+    start, end = _parse_time_range("2026-07-27/2026-07-27")
+    # 20:00-04:00 is 07:00 on the 28th in Asia/Jakarta -- outside.
+    assert _in_time_range("2026-07-27T20:00:00-04:00", start, end) is False
+
+
+def test_in_time_range_rejects_unparseable_and_non_datetime():
+    start, end = _parse_time_range("2026-07-27/2026-07-27")
+    assert _in_time_range("garbage", start, end) is False
+    assert _in_time_range(12345, start, end) is False
+
+
+# ── Writers keep producing a file when a timestamp carries an offset ─────────
+
+_AWARE_ITEM = {
+    "title": "Offset-bearing timestamp",
+    "publish_date": "2026-07-27T08:00:00-04:00",
+    "author": "Reporter",
+    "content": "Body text for the aware-timestamp writer regression.",
+    "keyword": "election",
+    "category": "news",
+    "source": "abcnews.com",
+    "link": "https://abcnews.com/story-1",
+}
+
+
+async def _drive(writer, path):
+    queue = asyncio.Queue()
+    await queue.put(dict(_AWARE_ITEM))
+    await queue.put(None)
+    await writer(
+        queue,
+        "test",
+        filename=str(path),
+        time_range=_parse_time_range("2026-07-27/2026-07-27"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_csv_keeps_row_with_aware_timestamp(tmp_path):
+    out = tmp_path / "out.csv"
+    await _drive(write_csv, out)
+    assert out.exists(), "writer died on the aware/naive comparison"
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert len(rows) == 1
+    assert rows[0]["link"] == _AWARE_ITEM["link"]
+
+
+@pytest.mark.asyncio
+async def test_write_json_keeps_row_with_aware_timestamp(tmp_path):
+    out = tmp_path / "out.json"
+    await _drive(write_json, out)
+    assert out.exists()
+    assert len(json.loads(out.read_text(encoding="utf-8"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_write_jsonl_keeps_row_with_aware_timestamp(tmp_path):
+    out = tmp_path / "out.jsonl"
+    await _drive(write_jsonl, out)
+    assert out.exists()
+    lines = [ln for ln in out.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_write_xlsx_keeps_row_with_aware_timestamp(tmp_path):
+    pd = pytest.importorskip("pandas")
+    out = tmp_path / "out.xlsx"
+    await _drive(write_xlsx, out)
+    assert out.exists()
+    assert len(pd.read_excel(out)) == 1
+
+
+@pytest.mark.asyncio
+async def test_api_collector_keeps_row_with_aware_timestamp():
+    from newswatch.api import _collect_queue_results
+
+    queue = asyncio.Queue()
+    await queue.put(dict(_AWARE_ITEM))
+    await queue.put(None)
+    done = asyncio.Event()
+    done.set()
+
+    results = await _collect_queue_results(
+        queue, done, time_range=_parse_time_range("2026-07-27/2026-07-27")
+    )
+    assert len(results) == 1
+    assert results[0]["link"] == _AWARE_ITEM["link"]


### PR DESCRIPTION
## Summary
- fix `parse_date` discarding the UTC offset instead of converting it: an article at `08:00-04:00` and one at `08:00+07:00` — 11 hours apart — landed on the same timestamp
- fix three more conventions disagreeing in the same output column: `bbc.py` flattened to UTC, `idnfinancials.py` used `astimezone(tz=None)`, which resolves to the runner machine's zone, so the same article yielded a different timestamp per host
- fix `--daterange` discarding the entire output file when a timestamp carries an offset: `fromisoformat` returns an aware datetime, the comparison against naive bounds raises `TypeError` not `ValueError`, so it escaped the parse guard — the CLI logged one line and never promoted its `.tmp`, the API propagated instead
- add ABC News and NBC News, both English-language, both filtering a robots-permitted discovery feed because their `/search` endpoints are disallowed

Latent until now because every registered source publishes at `+07:00`, so the four conventions never disagreed and no scraper ever queued an offset-bearing string. US sources are what trigger it, which is why the timezone work lands with the sources rather than after them.

## What's new
- `timeutils.to_project_naive` — single conversion point; reference zone `Asia/Jakarta`, override `NEWSWATCH_TIMEZONE`. Chosen over UTC because most registered sources already publish there, so their output is unchanged; UTC would have shifted all of them to fix a handful
- `_in_time_range` replaces five copies of the filter block across the four writers and `api.py`
- `abcnews`: `xmlLatestStories` news sitemap, 1000 entries over ~13 days. Entries carry `news:publication_date`, so the `start_date` cutoff applies before any article fetch
- `nbcnews`: `/archive/articles/{year}/{month}` lists a full calendar month (~1200 anchors, no pagination), so search walks the months spanned by `start_date` and gets real historical reach; `/sitemap/nbcnews/sitemap-news` for latest
- `nbcnews` overrides `fetch_search_results` — `BaseScraper`'s page loop stops at the first page with no links, which would let one keyword-less month hide every older month
- `nbcnews` bounds (12 months, 25 articles per keyword per run) log a warning naming the oldest month read, instead of returning partial coverage that looks complete
- sources 79 → 81, stable 77 → 79
- docs updated across README, architecture, troubleshooting, practical-guide, and changelog

## Tests
- `uv run --extra dev pytest tests/ -m "not network" --timeout=30 -q` — 1270 passed, 21 skipped, 230 deselected (34 new: `to_project_naive` conversion contracts, `parse_date` across `-04:00`/`+07:00`/`Z`/naive, aware-timestamp regression for all four writers plus the API collector, and offline extraction contracts for both new sources)
- `uv run --extra dev pytest tests/test_scrapers.py -m network -k "abcnews or nbcnews"` — 4 passed
- `uv run --extra dev ruff check` — passed
- `make sources-check` — passed
- `uv lock --check` — passed
- mixed Indonesian + US run, `--keywords polisi,police --scrapers kompas,abcnews --daterange 2026-07-24/2026-07-27` — 48 rows, 20 kompas + 28 ABC, single clock, file written
- only three existing test expectations changed, all for sources that were flattening to UTC; kompas parses visible WIB display text with no offset and passes through untouched

## Notes
- any source reporting an offset other than `+07:00` shifts by the difference — the global English sources (BBC, AP News, Al Jazeera, and the two added here) plus The Conversation Indonesia, Independen, IDN Financials. AP News emits `Z` and Al Jazeera `+0000`, both through the shared helper
- both new sources honor `robots.txt`: their `/search` endpoints are disallowed, so keyword search filters a permitted news sitemap or archive page instead — the approach `detik`, `kumparan` and `idxchannel` already use
- source feasibility must be probed through the project's own client (`AsyncScraper.fetch`, with its rnet and Playwright fallbacks). An initial pass via a third-party fetcher reported `451`/`403` on endpoints that respond normally to this project's stack; those were reputation artifacts, not site posture