### PR TITLE
chore: prepare release 1.2.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - name: "Okky Mabruri"
     website: "okkymabruri.github.io"
     orcid: "https://orcid.org/0000-0002-2103-1311"
-version: 1.2.4
+version: 1.2.5
 abstract: "news-watch: Indonesia's top news websites scraper. A Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 publisher: Zenodo
 doi: "10.5281/zenodo.14908389"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-07-27
+
 ### Added
 - ABC News and NBC News sources, both English-language. ABC filters the `xmlLatestStories` news sitemap (~13-day window); NBC walks its monthly archive pages, giving keyword search real historical reach
 - `NEWSWATCH_TIMEZONE` environment variable setting the zone that naive `publish_date` values and `--time_range` boundaries are expressed in (default `Asia/Jakarta`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "news-watch"
-version = "1.2.4"
+version = "1.2.5"
 description = "news-watch is a Python package that scrapes structured news data from Indonesia's top news websites, offering keyword and date filtering queries for targeted research."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/newswatch/__init__.py
+++ b/src/newswatch/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 # health report
 from .health import health_report as health_report

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "news-watch"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version metadata bump to 1.2.5 and the changelog header for the entries already under `[Unreleased]`.

Contents: timezone normalization across all sources, the time-range writer fix, and the ABC News and NBC News adapters (#50).

Gates: `release-validate`, ruff, 1270 passed / 21 skipped, `sources-check`, `uv lock --check` all clean.