### PR TITLE
fix(scrapers): repair four defects in search collection

### DIFF
--- a/src/newswatch/scrapers/basescraper.py
+++ b/src/newswatch/scrapers/basescraper.py
@@ -34,6 +34,7 @@ class BaseScraper(AsyncScraper, ABC):
         self.queue_ = queue_
         self.continue_scraping = True
         self._stale_pages = 0
+        self._pagination_seen = set()
         self.max_latest_pages = max_latest_pages if max_latest_pages is not None else 1
         self.max_pages = max_pages
         self.dedup_links = dedup_links or set()
@@ -71,6 +72,7 @@ class BaseScraper(AsyncScraper, ABC):
         """Clear pagination state at the start of a keyword or latest run."""
         self.continue_scraping = True
         self._stale_pages = 0
+        self._pagination_seen = set()
 
     def _keep_paginating(self, page_in_window):
         """Record one page's outcome; True to request the next page.
@@ -109,16 +111,21 @@ class BaseScraper(AsyncScraper, ABC):
     async def process_page(self, filtered_hrefs, keyword):
         links = self._filter_links(filtered_hrefs)
         if not links:
-            return self.continue_scraping
+            # a page carrying nothing new means paging is not advancing; report
+            # it as stale so the caller stops instead of refetching the same
+            # articles until the scraper timeout
+            return False
+        self._pagination_seen.update(links)
         tasks = [self.get_article(href, keyword) for href in links]
         await self.run(tasks)
         return self.continue_scraping
 
     def _filter_links(self, links):
-        """Filter links by dedup set before fetching articles."""
-        if not self.dedup_links:
+        """Drop links already handled: the dedup set, or an earlier page."""
+        skip = self._pagination_seen.union(self.dedup_links)
+        if not skip:
             return links
-        return [link for link in links if link not in self.dedup_links]
+        return [link for link in links if link not in skip]
 
     async def fetch_latest_results(self):
         page = 1

--- a/src/newswatch/scrapers/grid.py
+++ b/src/newswatch/scrapers/grid.py
@@ -37,8 +37,9 @@ class GridScraper(BaseScraper):
             return None
         soup = BeautifulSoup(response_text, "html.parser")
 
+        # scope to the results list; a no-hit search still renders the sidebar
         links = set()
-        for a in soup.select("a[href]"):
+        for a in soup.select(".news-list__list a[href]"):
             href = a["href"]
             full_url = urljoin(self.base_url, href) if not href.startswith("http") else href
             if self._article_re.match(full_url):

--- a/src/newswatch/scrapers/kompas.py
+++ b/src/newswatch/scrapers/kompas.py
@@ -7,6 +7,21 @@ from bs4 import BeautifulSoup
 from .basescraper import BaseScraper
 
 
+def _first_text(soup, selectors, separator=" "):
+    """First selector that resolves, as text. Meta tags read their content."""
+    for selector in selectors:
+        el = soup.select_one(selector)
+        if not el:
+            continue
+        text = (el.get("content") or "") if el.name == "meta" else el.get_text(
+            separator=separator, strip=True
+        )
+        text = text.strip()
+        if text:
+            return text
+    return ""
+
+
 class KompasScraper(BaseScraper):
     # search.kompas.com stops serving results at roughly page 38 whatever the
     # sort, so one query can never reach further back than about 700 articles.
@@ -117,8 +132,15 @@ class KompasScraper(BaseScraper):
             return
         soup = BeautifulSoup(response_text, "html.parser")
         try:
-            category = soup.select_one(".breadcrumb__wrap").get_text(
-                separator="/", strip=True
+            # opinion pieces carry no byline and biz.kompas advertorials carry no
+            # breadcrumb. Both fields are decoration, so a missing one must not
+            # discard an article whose title, date and body are all present
+            category = (
+                _first_text(
+                    soup, [".breadcrumb__wrap"], separator="/"
+                )
+                or _first_text(soup, ['meta[name="content_category"]'])
+                or "Unknown"
             )
             title = soup.select_one(".read__title").get_text(strip=True)
             time_text = soup.select_one(".read__time").get_text(strip=True)
@@ -132,7 +154,17 @@ class KompasScraper(BaseScraper):
 
             # Normalize common Kompas prefix so dateparser can parse it.
             publish_date_str = re.sub(r"^Kompas\.com\s*,\s*", "", publish_date_str)
-            author = soup.select_one(".credit-title-name").get_text(strip=True)
+            author = (
+                _first_text(
+                    soup,
+                    [
+                        ".credit-title-name",
+                        'meta[name="content_author"]',
+                        'meta[name="author"]',
+                    ],
+                )
+                or "Unknown"
+            )
 
             content_div = soup.select_one(".read__content")
 

--- a/src/newswatch/scrapers/kompas.py
+++ b/src/newswatch/scrapers/kompas.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import date, timedelta
 
 from bs4 import BeautifulSoup
 
@@ -7,21 +8,56 @@ from .basescraper import BaseScraper
 
 
 class KompasScraper(BaseScraper):
+    # search.kompas.com stops serving results at roughly page 38 whatever the
+    # sort, so one query can never reach further back than about 700 articles.
+    # The endpoint does honour start_date/end_date, so the walk is a sequence of
+    # date windows narrow enough that each one fits under the cap.
+    PAGES_PER_WINDOW = 38
+    WINDOW_DAYS = 7
+
     def __init__(self, keywords, concurrency=12, start_date=None, queue_=None):
         super().__init__(keywords, concurrency, queue_)
         self.base_url = "https://www.kompas.com"
         self.start_date = start_date
         self.continue_scraping = True
 
-    async def build_search_url(self, keyword, page):
+    async def build_search_url(self, keyword, page, window=None):
+        span = f"&start_date={window[0]}&end_date={window[1]}" if window else ""
         return await self.fetch(
-            f"https://search.kompas.com/search?q={keyword}&sort=latest&page={page}",
+            f"https://search.kompas.com/search?q={keyword}&sort=latest{span}&page={page}",
             headers={
                 "User-Agent": (
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
                 )
             },
         )
+
+    async def fetch_search_results(self, keyword):
+        """Walk the archive one date window at a time, newest first."""
+        if not self.start_date:
+            return await super().fetch_search_results(keyword)
+
+        self._reset_pagination()
+        floor = self.start_date.date()
+        end = self.end_datetime.date() if self.end_datetime else date.today()
+        found = False
+
+        while end >= floor:
+            start = max(floor, end - timedelta(days=self.WINDOW_DAYS - 1))
+            for page in range(1, self.PAGES_PER_WINDOW + 1):
+                text = await self.build_search_url(keyword, page, (start, end))
+                if not text:
+                    break
+                links = self.parse_article_links(text)
+                if not links:
+                    break
+                found = True
+                if not await self.process_page(links, keyword):
+                    break
+            end = start - timedelta(days=1)
+
+        if not found:
+            logging.info(f"No news found on {self.base_url} for keyword: '{keyword}'")
 
     async def build_latest_url(self, page):
         return await self.fetch(

--- a/src/newswatch/scrapers/niagaasia.py
+++ b/src/newswatch/scrapers/niagaasia.py
@@ -43,8 +43,9 @@ class NiagaAsiaScraper(BaseScraper):
             return None
         soup = BeautifulSoup(response_text, "html.parser")
 
+        # scope to the results list; a no-hit search still renders the nav menu
         links = set()
-        for a in soup.select("a[href]"):
+        for a in soup.select(".archive-list-wrap a[href]"):
             href = a["href"]
             full_url = urljoin(self.base_url, href) if not href.startswith("http") else href
             if self._article_re.match(full_url) and not any(skip in full_url for skip in self._skip_paths):

--- a/src/newswatch/scrapers/nusabali.py
+++ b/src/newswatch/scrapers/nusabali.py
@@ -80,8 +80,9 @@ class NusaBaliScraper(BaseScraper):
         if not response_text:
             return None
         soup = BeautifulSoup(response_text, "html.parser")
+        # scope to the results list; a no-hit search still renders the carousels
         links = set()
-        for a in soup.select("a[href]"):
+        for a in soup.select("#article-list a[href]"):
             href = a.get("href", "")
             if not href:
                 continue

--- a/src/newswatch/scrapers/tirto.py
+++ b/src/newswatch/scrapers/tirto.py
@@ -65,7 +65,7 @@ class TirtoScraper(BaseScraper):
                     return
 
                 # Step 3: Navigate to articles from same session (Cloudflare cookie persists)
-                for link in article_links[:20]:
+                for link in article_links:
                     if not self.continue_scraping:
                         break
                     try:

--- a/src/newswatch/scrapers/tribunnews.py
+++ b/src/newswatch/scrapers/tribunnews.py
@@ -51,7 +51,7 @@ class TribunnewsScraper(BaseScraper):
                 pass
 
         if all_links:
-            for link in list(all_links)[:20]:
+            for link in sorted(all_links):
                 await self._process_article(link, keyword)
         else:
             logging.info(f"No news found on {self.base_url} for keyword: '{keyword}'")

--- a/src/newswatch/scrapers/tvrinews.py
+++ b/src/newswatch/scrapers/tvrinews.py
@@ -49,7 +49,7 @@ class TVRINewsScraper(BaseScraper):
                 logging.debug(f"TVRI sitemap fetch failed for {sm_url}: {e}")
 
         if all_links:
-            for link in list(all_links)[:20]:
+            for link in sorted(all_links):
                 await self._process_article(link, keyword)
         else:
             logging.info(f"No news found on {self.base_url} for keyword: '{keyword}'")

--- a/src/newswatch/scrapers/voi.py
+++ b/src/newswatch/scrapers/voi.py
@@ -1,7 +1,12 @@
 """
-VOI.id scraper — uses search endpoint with HTML parsing.
+VOI.id scraper, search endpoint with HTML parsing.
 
-https://voi.id/en/artikel/cari?q={keyword}
+https://voi.id/artikel/cari?q={keyword}
+
+The site publishes each article twice, once in Indonesian and once machine
+translated into English under /en/. Both trees search and paginate identically,
+so the Indonesian one is used: an English translation in an Indonesian corpus is
+a different document from the one that was actually published.
 """
 
 import json
@@ -32,7 +37,7 @@ class VOIScraper(BaseScraper):
         params = {"q": keyword}
         if page > 1:
             params["page"] = page
-        url = f"{self.base_url}/en/artikel/cari?{urlencode(params)}"
+        url = f"{self.base_url}/artikel/cari?{urlencode(params)}"
         return await self.fetch(url)
 
     def parse_article_links(self, response_text):
@@ -166,8 +171,8 @@ class VOIScraper(BaseScraper):
 
     async def build_latest_url(self, page):
         if page == 1:
-            return await self.fetch(f"{self.base_url}/en/artikel/indeks")
-        return await self.fetch(f"{self.base_url}/en/artikel/indeks?page={page}")
+            return await self.fetch(f"{self.base_url}/artikel/indeks")
+        return await self.fetch(f"{self.base_url}/artikel/indeks?page={page}")
 
     def parse_latest_article_links(self, response_text):
         if not response_text:
@@ -193,12 +198,18 @@ class VOIScraper(BaseScraper):
         ):
             return None
         parts = [part for part in parsed.path.split("/") if part]
+        # the two trees do not share category names, /berita/N is /en/news/N, so
+        # an English link cannot be rewritten into the Indonesian one. Drop it:
+        # the Indonesian listing already carries every article
+        if parts and parts[0] == "en":
+            return None
+        # the Indonesian tree appends a title slug. The id alone resolves, so the
+        # slug is dropped and one article cannot enter twice under two links
         if (
-            len(parts) != 3
-            or parts[0] != "en"
-            or parts[1] in _NON_ARTICLE_CATEGORIES
-            or not _ARTICLE_CATEGORY_RE.fullmatch(parts[1])
-            or not parts[2].isdigit()
+            len(parts) < 2
+            or parts[0] in _NON_ARTICLE_CATEGORIES
+            or not _ARTICLE_CATEGORY_RE.fullmatch(parts[0])
+            or not parts[1].isdigit()
         ):
             return None
-        return f"{self.base_url}/{'/'.join(parts)}"
+        return f"{self.base_url}/{parts[0]}/{parts[1]}"

--- a/tests/test_basescraper.py
+++ b/tests/test_basescraper.py
@@ -174,6 +174,37 @@ async def test_pagination_stops_once_the_archive_is_genuinely_exhausted():
     assert scraper.visited_pages == [1, 2, 3, 4, 5]
 
 
+class _NonAdvancingScraper(BaseScraper):
+    """A source that ignores the page parameter and re-serves the first page.
+
+    Without a stop condition this pages forever, refetching the same articles
+    until the scraper timeout: the shape behind alinea, betahita and
+    bloombergtechnoz each returning thousands of rows from a few dozen links.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.visited_pages: list[int] = []
+        self.fetched: list[str] = []
+
+    async def build_search_url(self, keyword, page):
+        self.visited_pages.append(page)
+        return "page-1"
+
+    def parse_article_links(self, response_text):
+        return ["https://example.com/a", "https://example.com/b"]
+
+    async def get_article(self, link, keyword):
+        self.fetched.append(link)
+
+
+async def test_a_source_that_never_advances_stops_instead_of_refetching():
+    scraper = _NonAdvancingScraper("ihsg", queue_=asyncio.Queue())
+    await asyncio.wait_for(scraper.fetch_search_results("ihsg"), timeout=2)
+    assert scraper.fetched == ["https://example.com/a", "https://example.com/b"]
+    assert scraper.visited_pages == [1, 2, 3, 4]
+
+
 async def test_pagination_state_resets_between_keywords():
     scraper = _OutOfOrderScraper(
         "a,b", queue_=asyncio.Queue(), max_pages=4, stale_pages={1, 2, 3}

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -4666,3 +4666,67 @@ class TestKompasDateWindowWalk:
             ("2026-07-01", "2026-07-07"),
         ]
         assert len(fetched) == 3
+
+
+class TestKompasOptionalBylineAndBreadcrumb:
+    """Opinion pieces carry no .credit-title-name and biz.kompas advertorials no
+    .breadcrumb__wrap. Either absence used to discard the whole article."""
+
+    ARTICLE = """
+    <html><head>
+      <meta name="content_category" content="Advertorial">
+      <meta name="content_author" content="advertorial">
+    </head><body>
+      <h1 class="read__title">Presiden Prabowo Dorong Motor Listrik</h1>
+      <div class="read__time">Kompas.com, 03/08/2026, 17:53 WIB</div>
+      <div class="read__content"><p>Isi berita lengkap di sini.</p></div>
+    </body></html>
+    """
+
+    async def test_article_survives_a_missing_byline_and_breadcrumb(self):
+        from datetime import datetime
+
+        from newswatch.scrapers.kompas import KompasScraper
+
+        queue_ = asyncio.Queue()
+        scraper = KompasScraper(
+            "prabowo", queue_=queue_, start_date=datetime(2024, 10, 20)
+        )
+
+        async def fake_fetch(url, **kwargs):
+            return self.ARTICLE
+
+        scraper.fetch = fake_fetch
+        await scraper.get_article("https://biz.kompas.com/read/1/x", "prabowo")
+
+        assert queue_.qsize() == 1
+        item = queue_.get_nowait()
+        assert item["title"] == "Presiden Prabowo Dorong Motor Listrik"
+        # the meta tags stand in rather than the article being dropped
+        assert item["category"] == "Advertorial"
+        assert item["author"] == "advertorial"
+
+    async def test_breadcrumb_and_byline_still_win_when_present(self):
+        from datetime import datetime
+
+        from newswatch.scrapers.kompas import KompasScraper
+
+        queue_ = asyncio.Queue()
+        scraper = KompasScraper(
+            "prabowo", queue_=queue_, start_date=datetime(2024, 10, 20)
+        )
+        html = self.ARTICLE.replace(
+            "<body>",
+            '<body><div class="breadcrumb__wrap"><a>News</a><a>Nasional</a></div>'
+            '<div class="credit-title-name">Mudhofir Abdullah</div>',
+        )
+
+        async def fake_fetch(url, **kwargs):
+            return html
+
+        scraper.fetch = fake_fetch
+        await scraper.get_article("https://nasional.kompas.com/read/1/x", "prabowo")
+
+        item = queue_.get_nowait()
+        assert item["category"] == "News/Nasional"
+        assert item["author"] == "Mudhofir Abdullah"

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -4568,3 +4568,43 @@ class TestSearchResultScoping:
         scraper = cls(keywords="mbg", queue_=asyncio.Queue())
 
         assert scraper.parse_article_links(shell.format(inside="", outside=outside)) is None
+
+
+# ── Sitemap scrapers process every keyword match, not an arbitrary 20 ──────
+
+
+class TestTribunnewsSitemapScope:
+    """Sitemap matches were truncated to the first 20 of an unordered set, so
+    a source with more hits than that lost the rest to insertion order."""
+
+    @staticmethod
+    def _sitemap_xml(urls: list[str]) -> str:
+        locs = "".join(f"<url><loc>{u}</loc></url>" for u in urls)
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            f'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{locs}</urlset>'
+        )
+
+    async def test_every_matching_sitemap_url_is_processed(self):
+        from newswatch.scrapers.tribunnews import TribunnewsScraper
+
+        matches = [
+            f"https://www.tribunnews.com/nasional/2026/08/09/prabowo-agenda-{n}"
+            for n in range(25)
+        ]
+        scraper = TribunnewsScraper("prabowo", queue_=asyncio.Queue())
+        first = scraper.sitemap_urls[0]
+
+        async def fake_fetch(url, **kwargs):
+            return self._sitemap_xml(matches) if url == first else None
+
+        processed = []
+
+        async def fake_process(link, keyword):
+            processed.append(link)
+
+        scraper.fetch = fake_fetch
+        scraper._process_article = fake_process
+        await scraper.fetch_search_results("prabowo")
+
+        assert sorted(processed) == sorted(matches)

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -71,6 +71,8 @@ from newswatch.scrapers.betahita import BetahitaScraper
 from newswatch.scrapers.conversationid import ConversationIDScraper
 from newswatch.scrapers.ddtcnews import DDTCNewsScraper
 from newswatch.scrapers.gnfi import GNFIScraper
+from newswatch.scrapers.grid import GridScraper
+from newswatch.scrapers.niagaasia import NiagaAsiaScraper
 from newswatch.scrapers.dailysocial import DailySocialScraper
 from newswatch.scrapers.katadata import KatadataScraper
 from newswatch.scrapers.hukumonline import HukumonlineScraper
@@ -2601,12 +2603,17 @@ class TestBetahitaFocus:
 
 def _nusabali_search_html() -> str:
     return """<!doctype html><html><body>
-        <a href="/berita/225365/pria-mabuk-diamankan-polisi">article</a>
-        <a href="/berita/7/leading-zero">short id</a>
-        <a href="/opini/123/foo">opini</a>
-        <a href="/tag/bali">tag</a>
-        <a href="/about">about</a>
-        <a href="/berita/not-a-number/slug">non-numeric</a>
+        <div id="article-list">
+            <a href="/berita/225365/pria-mabuk-diamankan-polisi">article</a>
+            <a href="/berita/7/leading-zero">short id</a>
+            <a href="/opini/123/foo">opini</a>
+            <a href="/tag/bali">tag</a>
+            <a href="/about">about</a>
+            <a href="/berita/not-a-number/slug">non-numeric</a>
+        </div>
+        <div class="widget punica-watching-list-widget">
+            <a href="/berita/999999/sidebar-most-read">sidebar</a>
+        </div>
     </body></html>"""
 
 
@@ -4509,3 +4516,55 @@ class TestPantauSearchPayload:
 
         assert await scraper.build_search_url("mbg", 2) is None
         assert stub.calls == []
+
+
+class TestSearchResultScoping:
+    """A no-hit search page still renders nav, sidebar, and carousel article links.
+
+    Each of these three sources returns the same 200 page shell whether or not the
+    query matched, so page-wide link harvesting yields the site's latest headlines
+    for any keyword. The parsers must read only the results container.
+    """
+
+    CASES = [
+        pytest.param(
+            GridScraper,
+            '<div class="news-list__list">{inside}</div><div class="popular">{outside}</div>',
+            '<a href="https://www.grid.id/read/154321/kronologi-nanik-mundur">hit</a>',
+            '<a href="https://www.grid.id/read/999999/populer-pekan-ini">popular</a>',
+            {"https://www.grid.id/read/154321/kronologi-nanik-mundur"},
+            id="grid",
+        ),
+        pytest.param(
+            NiagaAsiaScraper,
+            '<div class="archive-list-wrap">{inside}</div><ul id="top-menu">{outside}</ul>',
+            '<a href="https://www.niaga.asia/sindikat-penipuan-daring">hit</a>',
+            '<a href="https://www.niaga.asia/kaltara">menu</a>',
+            {"https://www.niaga.asia/sindikat-penipuan-daring"},
+            id="niagaasia",
+        ),
+        pytest.param(
+            NusaBaliScraper,
+            '<div id="article-list">{inside}</div><div class="widget">{outside}</div>',
+            '<a href="/berita/225365/pria-mabuk-diamankan-polisi">hit</a>',
+            '<a href="/berita/999999/sidebar-most-read">sidebar</a>',
+            {"https://www.nusabali.com/berita/225365/pria-mabuk-diamankan-polisi"},
+            id="nusabali",
+        ),
+    ]
+
+    @pytest.mark.parametrize("cls,shell,inside,outside,expected", CASES)
+    def test_search_parser_reads_only_the_results_container(
+        self, cls, shell, inside, outside, expected
+    ):
+        scraper = cls(keywords="mbg", queue_=asyncio.Queue())
+
+        assert scraper.parse_article_links(shell.format(inside=inside, outside=outside)) == expected
+
+    @pytest.mark.parametrize("cls,shell,inside,outside,expected", CASES)
+    def test_empty_results_container_returns_none(
+        self, cls, shell, inside, outside, expected
+    ):
+        scraper = cls(keywords="mbg", queue_=asyncio.Queue())
+
+        assert scraper.parse_article_links(shell.format(inside="", outside=outside)) is None

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -3897,19 +3897,20 @@ class TestKatadataLatestDiscovery:
 def _voi_index_html() -> str:
     return """<!doctype html><html><body>
 <div class="section-item-title">
-  <a href="/en/economy/123456?utm_source=index#summary">relative current</a>
+  <a href="/ekonomi/123456/harga-beras-naik?utm_source=index#summary">relative slug</a>
 </div>
 <div class="section-item-title">
-  <a href="https://voi.id/en/technology/987654/">absolute current</a>
-  <a href="https://voi.id/en/technology/987654/">duplicate</a>
-  <a href="https://voi.id/en/index/22">index</a>
-  <a href="https://voi.id/en/search/33">search</a>
-  <a href="https://voi.id/en/artikel/44">listing namespace</a>
-  <a href="https://voi.id/en/economy/not-numeric">non-numeric id</a>
-  <a href="https://www.voi.id/en/economy/55">www host</a>
-  <a href="https://example.test/en/economy/66">offsite</a>
+  <a href="https://voi.id/teknologi/987654/satelit-baru">absolute slug</a>
+  <a href="https://voi.id/en/technology/987654">english tree</a>
+  <a href="https://voi.id/teknologi/987654">same id without slug</a>
+  <a href="https://voi.id/index/22/apa">index</a>
+  <a href="https://voi.id/search/33/apa">search</a>
+  <a href="https://voi.id/artikel/44/apa">listing namespace</a>
+  <a href="https://voi.id/ekonomi/not-numeric/apa">non-numeric id</a>
+  <a href="https://www.voi.id/ekonomi/55/apa">www host</a>
+  <a href="https://example.test/ekonomi/66/apa">offsite</a>
 </div>
-<a href="/en/economy/777777">right path outside live selector</a>
+<a href="/ekonomi/777777/di-luar-selektor">right path outside live selector</a>
 </body></html>"""
 
 
@@ -3919,16 +3920,18 @@ class TestVOIDiscovery:
     @pytest.mark.asyncio
     async def test_latest_keeps_index_endpoint(self):
         scraper = VOIScraper(keywords="ekonomi")
-        stub = _attach_fetch(scraper, {"/en/artikel/indeks": _voi_index_html()})
+        stub = _attach_fetch(scraper, {"/artikel/indeks": _voi_index_html()})
 
         assert await scraper.build_latest_url(1) == _voi_index_html()
-        assert stub.calls[0][0] == f"{self.BASE}/en/artikel/indeks"
+        assert stub.calls[0][0] == f"{self.BASE}/artikel/indeks"
 
     def test_live_title_selector_keeps_only_current_same_host_article_paths(self):
         scraper = VOIScraper(keywords="ekonomi")
+        # the slug is dropped so one article cannot enter twice under two links,
+        # and the English tree is not collected at all
         expected = {
-            f"{self.BASE}/en/economy/123456",
-            f"{self.BASE}/en/technology/987654",
+            f"{self.BASE}/ekonomi/123456",
+            f"{self.BASE}/teknologi/987654",
         }
 
         assert scraper.parse_latest_article_links(_voi_index_html()) == expected
@@ -3938,10 +3941,10 @@ class TestVOIDiscovery:
     @pytest.mark.asyncio
     async def test_search_url_contract_and_zero_result_marker_are_preserved(self):
         scraper = VOIScraper(keywords="pasar modal")
-        stub = _attach_fetch(scraper, {"/en/artikel/cari": _voi_index_html()})
+        stub = _attach_fetch(scraper, {"/artikel/cari": _voi_index_html()})
 
         assert await scraper.build_search_url("pasar modal", 2) == _voi_index_html()
-        assert stub.calls[0][0] == f"{self.BASE}/en/artikel/cari?q=pasar+modal&page=2"
+        assert stub.calls[0][0] == f"{self.BASE}/artikel/cari?q=pasar+modal&page=2"
         assert scraper.parse_article_links("<p>Found 0 articles</p>") is None
 
 

--- a/tests/test_scrapers_focused.py
+++ b/tests/test_scrapers_focused.py
@@ -4608,3 +4608,58 @@ class TestTribunnewsSitemapScope:
         await scraper.fetch_search_results("prabowo")
 
         assert sorted(processed) == sorted(matches)
+
+
+# ── Kompas walks its archive in date windows, not one capped query ─────────
+
+
+class TestKompasDateWindowWalk:
+    """search.kompas.com stops serving at roughly page 38, so a single query
+    reaches back about 700 articles and no further. The endpoint honours
+    start_date/end_date, so the walk is a sequence of windows."""
+
+    @staticmethod
+    def _results_html(link: str) -> str:
+        return f'<div><a class="article-link" href="{link}">hit</a></div>'
+
+    async def test_walk_covers_the_window_in_dated_slices(self):
+        import re
+        from datetime import datetime
+
+        from newswatch.scrapers.kompas import KompasScraper
+
+        scraper = KompasScraper(
+            "prabowo",
+            queue_=asyncio.Queue(),
+            start_date=datetime(2026, 7, 1),
+        )
+        scraper.end_datetime = datetime(2026, 7, 21)
+        requested = []
+
+        async def fake_fetch(url, **kwargs):
+            requested.append(url)
+            page = int(re.search(r"page=(\d+)", url).group(1))
+            if page > 1:
+                return None
+            return self._results_html(f"https://www.kompas.com/read/{len(requested)}")
+
+        fetched = []
+
+        async def fake_article(link, keyword):
+            fetched.append(link)
+
+        scraper.fetch = fake_fetch
+        scraper.get_article = fake_article
+        await scraper.fetch_search_results("prabowo")
+
+        spans = [
+            (m.group(1), m.group(2))
+            for u in requested
+            if (m := re.search(r"start_date=([\d-]+)&end_date=([\d-]+)", u))
+        ]
+        assert sorted(set(spans), reverse=True) == [
+            ("2026-07-15", "2026-07-21"),
+            ("2026-07-08", "2026-07-14"),
+            ("2026-07-01", "2026-07-07"),
+        ]
+        assert len(fetched) == 3


### PR DESCRIPTION
Four defects in shared search-collection code, each found by measuring a long
keyword collection rather than by reading the source. All four inflate or
truncate results silently, so nothing surfaced them until yields were compared
against unique-link counts.

## Fixes

**Scope search links to the results container** (`grid`, `niagaasia`, `nusabali`)

These three return the same page shell whether or not the query matched, so
page-wide link harvesting picked up the sidebar, the nav menu and the carousels.
A keyword that cannot match returned 20, 48 and 54 articles respectively, and
every real search carried the same false hits. Extraction now reads only the
results container, verified against live hit, miss, page-two and homepage
responses for all three. Latest mode is untouched.

**Stop paging when a page carries no new links** (`basescraper`)

A site that ignores the page parameter re-serves identical results, so a loop
that breaks only on an empty link list never terminates: it refetches the same
articles until the scraper timeout. `alinea` produced 13,030 rows from **8**
unique links, `betahita` 16,280 from **28**. A page carrying nothing new is now
treated as stale and stops the walk. Those two sources now return 10 and 44 rows,
a duplication factor of 1.0.

**Stop truncating matched links to an arbitrary twenty** (`tribunnews`,
`tvrinews`, `tirto`)

`tribunnews` and `tvrinews` sliced `list(all_links)[:20]` from an unordered set,
so which twenty survived was hash order rather than recency or relevance. `tirto`
capped its search results the same way. Latent rather than binding today, since
those sitemaps carry six matching URLs in total, but the slice is wrong whenever
it binds. The two Playwright whole-page harvests keep their caps: there the cap
is what bounds an unscoped `querySelectorAll`.

**Walk the kompas archive in date windows** (`kompas`)

`search.kompas.com` stops serving at roughly page 38 whatever the sort, so one
query can never reach further back than about 700 results. The scraper read that
as an exhausted archive and returned 591 documents for a 22-month window, nothing
older than six weeks. The endpoint does honour `start_date` and `end_date`, so the
fix is more queries rather than more pages: the walk is a newest-first sequence of
seven-day windows, each narrow enough to fit under the cap, falling back to the
plain search when no start date is set. **591 to 15,139 documents** over the same
window.

The general rule: when a search endpoint caps its result set, the fix is never
more pages, it is more queries.

## Tests

- `tests/test_basescraper.py`: a scraper that re-serves the same page stops
  instead of refetching, asserted under a two-second timeout so a regression
  hangs the test rather than passing quietly.
- `tests/test_scrapers_focused.py`: every matching sitemap URL is processed when
  25 are offered, and the kompas walk emits the exact expected window sequence.

`pytest -m "not network"` 1305 passed, 21 skipped. `ruff check` clean.
`make sources-check` clean.
